### PR TITLE
Fix #61: don't clear tokens on transient refresh failures

### DIFF
--- a/src/web-ui/src/contexts/auth.test.tsx
+++ b/src/web-ui/src/contexts/auth.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { makeTokenPair, seedTokens } from "@/test/factories";
+import {
+  expectStillLoggedIn,
+  jsonResponse,
+  mockFetchSequence,
+} from "@/test/helpers";
+
+async function mountAuthProvider() {
+  vi.resetModules();
+  const [{ AuthProvider }, React] = await Promise.all([
+    import("./auth"),
+    import("react"),
+  ]);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      React.createElement(AuthProvider, null, React.createElement("div")),
+    );
+  });
+
+  return { root, container };
+}
+
+describe("AuthProvider on initial mount", () => {
+  it("keeps tokens when /me triggers a transient (5xx) refresh failure", async () => {
+    const tokens = makeTokenPair();
+    seedTokens(tokens);
+    mockFetchSequence(
+      jsonResponse({ status: 401 }),
+      jsonResponse({ status: 503, body: { detail: "Service Unavailable" } }),
+    );
+
+    await mountAuthProvider();
+
+    expectStillLoggedIn(tokens);
+  });
+});

--- a/src/web-ui/src/contexts/auth.tsx
+++ b/src/web-ui/src/contexts/auth.tsx
@@ -36,7 +36,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const userData = await api.auth.getCurrentUser();
           setUser(userData);
         } catch {
-          api.clearTokens();
+          // APIClient owns the clear-tokens decision (see base.ts): it clears
+          // on a real auth failure and dispatches "auth:logout", but keeps
+          // tokens on transient errors (5xx, network) so the user stays logged
+          // in once connectivity recovers. Don't second-guess it here.
         }
       }
       setIsLoading(false);

--- a/src/web-ui/src/test/setup.ts
+++ b/src/web-ui/src/test/setup.ts
@@ -1,5 +1,8 @@
 import { afterEach, vi } from "vitest";
 
+// React requires this to be set so act() works without a warning.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
 afterEach(() => {
   localStorage.clear();
   document.cookie.split(";").forEach((c) => {


### PR DESCRIPTION
AuthProvider.checkAuth caught all errors from getCurrentUser and called api.clearTokens(), which defeats APIClient's deliberate distinction between 'invalid' (clear tokens, fire auth:logout) and 'transient' (5xx, network — keep tokens). A single transient blip on /api/auth/refresh at page load forced re-login.

APIClient is now the sole authority on clearing tokens. AuthProvider's catch is a no-op.