### PR TITLE
Phase 3 chunk 3: API routes + schemas (articles, channels, notification updates)

### DIFF
--- a/openspec/changes/add-article-authoring/tasks.md
+++ b/openspec/changes/add-article-authoring/tasks.md
@@ -43,17 +43,17 @@
 
 - [x] 6.1 Add `HANDLERS.articles.add_channel`, `rename_channel`, `delete_channel`, `bulk_reassign_articles` methods on the same handler (per design 1a, channel CRUD lives on `HANDLERS.articles` rather than its own surface).
 - [x] 6.2 Wire the guards: `DuplicateChannelNameError`, `ChannelHasArticlesError(article_count)`, `LastChannelError` — the routes (chunk 3) map these to 409.
-- [ ] 6.3 Add API routes under `api/routers/channels.py`: `POST /api/projects/{slug}/channels`, `PATCH /api/projects/{slug}/channels/{id}`, `DELETE /api/projects/{slug}/channels/{id}`, `POST /api/projects/{slug}/channels/{id}/reassign`. _Deferred to chunk 3 (API routes)._
-- [ ] 6.4 Permission check on all routes: caller must be `ProjectContributor` with `full_edit = True` on the project. _Deferred to chunk 3 alongside 6.3._
+- [x] 6.3 Add API routes under `api/routers/channels.py`: `POST /api/projects/{slug}/channels`, `PATCH /api/projects/{slug}/channels/{id}`, `DELETE /api/projects/{slug}/channels/{id}`, `POST /api/projects/{slug}/channels/{id}/reassign`. Added `GET /api/projects/{slug}/channels` to feed the chunk-7 dropdown.
+- [x] 6.4 Permission check on all routes: caller must be `ProjectContributor` with `full_edit = True` on the project. Implemented via `REPO.project.user_can_edit`.
 
 ## 7. Backend — Article API routes
 
-- [ ] 7.1 Add `api/schemas/article.py` with `ArticleCreate`, `ArticleUpdate`, `ArticlePublish`, `ArticleOut`, `ArticleListItem` pydantic schemas.
-- [ ] 7.2 Add `api/routers/articles.py`: `POST /api/projects/{slug}/articles` (create draft), `GET /api/projects/{slug}/articles/{id}` (read for editor — includes drafts for authors/full-edit), `PATCH /api/projects/{slug}/articles/{id}` (update), `POST /api/projects/{slug}/articles/{id}/publish` (publish), `DELETE /api/projects/{slug}/articles/{id}`.
-- [ ] 7.3 Add `GET /api/projects/{slug}/articles/by-slug/{article_slug}` for the render page (public for published, 404 for drafts unless caller is author/full-edit).
-- [ ] 7.4 Permission checks on write paths: `full_edit` contributor. The route body SHALL be (a) parse body, (b) permission check, (c) exactly one `HANDLERS.articles.*` or `REPO.articles.*` call, (d) shape response. No `Article.objects`, `Channel.objects`, or `FollowChannelPreference.objects` references in `api/routers/articles.py` or `api/routers/channels.py`.
-- [ ] 7.5 Update `POST /api/notifications/mark-thread-read` body schema to accept `article_id` as a third alternative; reject 2-or-more or 0 of {root_discussion_id, comment_id, article_id} with 422.
-- [ ] 7.6 Update `GET /api/notifications/groups` response to include `kind` discriminator and article groups (project + channel + title + excerpt + article_id + article_slug).
+- [x] 7.1 Add `api/schemas/article.py` with `ArticleCreate`, `ArticleUpdate`, `ArticlePublish`, `ArticleOut`, `ArticleListItem` pydantic schemas. Channel request/response schemas live here too (`ChannelCreate`, `ChannelRename`, `ChannelReassign`, `ChannelResponse`, `ChannelConflictResponse`, `ChannelReassignResponse`).
+- [x] 7.2 Add `api/routers/articles.py`: `POST /api/projects/{slug}/articles` (create draft), `GET /api/projects/{slug}/articles/{id}` (read for editor — includes drafts for authors/full-edit), `PATCH /api/projects/{slug}/articles/{id}` (update), `POST /api/projects/{slug}/articles/{id}/publish` (publish), `DELETE /api/projects/{slug}/articles/{id}`. Added `GET /api/projects/{slug}/articles` for listing.
+- [x] 7.3 Add `GET /api/projects/{slug}/articles/by-slug/{article_slug}` for the render page (public for published, 404 for drafts unless caller is author/full-edit).
+- [x] 7.4 Permission checks on write paths: `full_edit` contributor via `REPO.project.user_can_edit`. Routes parse body → permission check → service-layer call → shape response; no ORM access in `api/routers/articles.py` or `api/routers/channels.py`.
+- [x] 7.5 Update `POST /api/notifications/mark-thread-read` body schema to accept `article_id` as a third alternative; reject 2-or-more or 0 of {root_discussion_id, comment_id, article_id} with 422.
+- [x] 7.6 Update `GET /api/notifications/groups` response to include `kind` discriminator and article groups (project + channel + title + excerpt + article_id + article_slug). `NotificationGroup` dataclass widened with optional article fields; `count_unread_groups_for_user` now sums distinct discussion roots + distinct article ids.
 
 ## 8. Backend — Send path flip in async-broadcast-send
 
@@ -74,11 +74,11 @@
 
 ## 10. Backend — OpenAPI + tests
 
-- [ ] 10.1 From `src/django-backend/`: `make extract-openapi`.
-- [ ] 10.2 Verify the spec includes the new article + channel + article-id-on-mark-thread-read endpoints.
+- [x] 10.1 From `src/django-backend/`: `make extract-openapi`.
+- [x] 10.2 Verify the spec includes the new article + channel + article-id-on-mark-thread-read endpoints.
 - [ ] 10.3 Add `apps/articles/tests/` covering: model save guards, slug generation + collision suffix, publish state transitions, edit-after-publish, delete, backdated-publish notification suppression, approval flow combinations (trust True / False / admin-demoted).
 - [ ] 10.4 Add `apps/notifications/tests/` covering: nullable FK constraint, partial unique constraints, mixed digest rendering, `mark_article_read_for_user`.
-- [ ] 10.5 Add API tests under `api/routers/test_articles.py` and `api/routers/test_channels.py` covering: 401 / 403 / 404 / 409 / 422 paths and the success paths.
+- [x] 10.5 Add API tests under `api/routers/test_articles.py` and `api/routers/test_channels.py` covering: 401 / 403 / 404 / 409 / 422 paths and the success paths. Also extended `test_notifications.py` with article-kind groups + article-id `mark-thread-read` cases.
 - [ ] 10.6 Update `api/routers/test_users.py` to remove assertions on the dropped fields and add assertions for `article_trust` if surfaced via UserOut (decide based on whether admins / users see it).
 - [ ] 10.7 Run `make lint` + `make test` until green from `src/django-backend/`.
 

--- a/src/django-backend/api/main.py
+++ b/src/django-backend/api/main.py
@@ -4,7 +4,9 @@ from django.http import HttpRequest
 from ninja import NinjaAPI
 
 from api.routers import (
+    articles,
     auth,
+    channels,
     competitions,
     discussions,
     follows,
@@ -27,6 +29,8 @@ api.add_router("/auth", auth.router)
 api.add_router("/projects", projects.router)
 api.add_router("/projects", discussions.router)
 api.add_router("/projects", follows.router)
+api.add_router("/projects", articles.router)
+api.add_router("/projects", channels.router)
 api.add_router("/follows", follows.collection_router)
 api.add_router("/my/projects", my_projects.router)
 api.add_router("/my/reviews", my_review.router)

--- a/src/django-backend/api/routers/_helpers.py
+++ b/src/django-backend/api/routers/_helpers.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from api.auth.jwt import get_user_from_token
+from apps.projects.models import ProjectStatus
+from services import REPO
+from services.project.exceptions import ProjectNotFoundError
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from django.http import HttpRequest
+
+    from apps.projects.models import Project
+    from apps.users.models import User
+
+
+def get_optional_user(request: HttpRequest) -> User | None:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        return get_user_from_token(auth_header[7:])
+    return None
+
+
+def resolve_project_or_404(
+    slug: str,
+) -> Project | tuple[int, dict[str, str]]:
+    try:
+        return REPO.project.get_by_identifier(slug)
+    except ProjectNotFoundError:
+        return 404, {"detail": "Project not found"}
+
+
+def require_full_edit(slug: str, user_id: UUID) -> Project | tuple[int, dict[str, str]]:
+    resolved = resolve_project_or_404(slug)
+    if isinstance(resolved, tuple):
+        return resolved
+    if not REPO.project.user_can_edit(resolved.id, user_id):
+        return 403, {"detail": "You don't have edit access to this project"}
+    return resolved
+
+
+def resolve_visible_project_or_404(
+    slug: str, user: User | None
+) -> Project | tuple[int, dict[str, str]]:
+    resolved = resolve_project_or_404(slug)
+    if isinstance(resolved, tuple):
+        return resolved
+    if resolved.status == ProjectStatus.APPROVED:
+        return resolved
+    if user is not None and user.is_superuser:
+        return resolved
+    if user is not None and REPO.project.user_can_edit(resolved.id, user.id):
+        return resolved
+    return 404, {"detail": "Project not found"}

--- a/src/django-backend/api/routers/articles.py
+++ b/src/django-backend/api/routers/articles.py
@@ -1,0 +1,243 @@
+from uuid import UUID
+
+from django.http import HttpRequest
+from ninja import Router
+
+from api.auth.jwt import get_user_from_token
+from api.auth.security import auth
+from api.schemas.article import (
+    ArticleCreate,
+    ArticleListItem,
+    ArticleOut,
+    ArticlePublish,
+    ArticleUpdate,
+)
+from api.schemas.errors import Error
+from apps.articles.models import Article, ArticleState
+from apps.projects.models import Project
+from apps.users.models import User
+from services import HANDLERS, REPO
+from services.articles.exceptions import (
+    ArticleNotFoundError,
+    ArticleNotPublishableError,
+    ChannelNotFoundError,
+    ChannelOnWrongProjectError,
+    HeroImageOnWrongProjectError,
+)
+from services.project.exceptions import ProjectNotFoundError
+
+router = Router()
+
+
+def _get_optional_user(request: HttpRequest) -> User | None:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        return get_user_from_token(auth_header[7:])
+    return None
+
+
+def _can_view_draft(article: Article, user: User | None) -> bool:
+    if user is None:
+        return False
+    if article.author_id == user.id:
+        return True
+    return REPO.project.user_can_edit(article.project_id, user.id)
+
+
+def _resolve_project_or_404(
+    slug: str,
+) -> Project | tuple[int, dict[str, str]]:
+    try:
+        return REPO.project.get_by_identifier(slug)
+    except ProjectNotFoundError:
+        return 404, {"detail": "Project not found"}
+
+
+def _require_full_edit(
+    slug: str, user_id: UUID
+) -> Project | tuple[int, dict[str, str]]:
+    resolved = _resolve_project_or_404(slug)
+    if isinstance(resolved, tuple):
+        return resolved
+    if not REPO.project.user_can_edit(resolved.id, user_id):
+        return 403, {"detail": "You don't have edit access to this project"}
+    return resolved
+
+
+@router.post(
+    "/{slug}/articles",
+    response={201: ArticleOut, 401: Error, 403: Error, 404: Error, 422: Error},
+    auth=auth,
+    tags=["Articles"],
+)
+def create_article(
+    request: HttpRequest,
+    slug: str,
+    payload: ArticleCreate,
+) -> tuple[int, Article] | tuple[int, dict[str, str]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    try:
+        article = HANDLERS.articles.create_draft(
+            project_id=project.id,
+            channel_id=payload.channel_id,
+            author_id=request.auth.id,
+            title=payload.title,
+            body=payload.body,
+            hero_image_id=payload.hero_image_id,
+        )
+    except (ChannelNotFoundError, ChannelOnWrongProjectError):
+        return 404, {"detail": "Channel not found on this project"}
+    except HeroImageOnWrongProjectError:
+        return 422, {"detail": "Hero image must belong to this project"}
+    return 201, article
+
+
+@router.get(
+    "/{slug}/articles",
+    response={200: list[ArticleListItem], 404: Error},
+    tags=["Articles"],
+)
+def list_articles(
+    request: HttpRequest,
+    slug: str,
+) -> list[Article] | tuple[int, dict[str, str]]:
+    project = _resolve_project_or_404(slug)
+    if isinstance(project, tuple):
+        return project
+    user = _get_optional_user(request)
+    include_drafts = user is not None and REPO.project.user_can_edit(
+        project.id, user.id
+    )
+    return list(REPO.articles.for_project(project.id, include_drafts=include_drafts))
+
+
+@router.get(
+    "/{slug}/articles/by-slug/{article_slug}",
+    response={200: ArticleOut, 404: Error},
+    tags=["Articles"],
+)
+def get_article_by_slug(
+    request: HttpRequest,
+    slug: str,
+    article_slug: str,
+) -> Article | tuple[int, dict[str, str]]:
+    article = REPO.articles.get_by_project_and_slug(slug, article_slug)
+    if article is None:
+        return 404, {"detail": "Article not found"}
+    if article.state != ArticleState.PUBLISHED:
+        user = _get_optional_user(request)
+        if not _can_view_draft(article, user):
+            return 404, {"detail": "Article not found"}
+    return article
+
+
+@router.get(
+    "/{slug}/articles/{article_id}",
+    response={200: ArticleOut, 401: Error, 403: Error, 404: Error},
+    auth=auth,
+    tags=["Articles"],
+)
+def get_article(
+    request: HttpRequest,
+    slug: str,
+    article_id: UUID,
+) -> Article | tuple[int, dict[str, str]]:
+    project = _resolve_project_or_404(slug)
+    if isinstance(project, tuple):
+        return project
+    article = REPO.articles.get_by_id(article_id)
+    if article is None or article.project_id != project.id:
+        return 404, {"detail": "Article not found"}
+    if article.state != ArticleState.PUBLISHED and not _can_view_draft(
+        article, request.auth
+    ):
+        return 403, {"detail": "You don't have access to this draft"}
+    return article
+
+
+@router.patch(
+    "/{slug}/articles/{article_id}",
+    response={200: ArticleOut, 401: Error, 403: Error, 404: Error, 422: Error},
+    auth=auth,
+    tags=["Articles"],
+)
+def patch_article(
+    request: HttpRequest,
+    slug: str,
+    article_id: UUID,
+    payload: ArticleUpdate,
+) -> Article | tuple[int, dict[str, str]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    existing = REPO.articles.get_by_id(article_id)
+    if existing is None or existing.project_id != project.id:
+        return 404, {"detail": "Article not found"}
+    try:
+        article = HANDLERS.articles.update_article(
+            article_id,
+            title=payload.title,
+            body=payload.body,
+            hero_image_id=payload.hero_image_id,
+            channel_id=payload.channel_id,
+            published_at=payload.published_at,
+        )
+    except ArticleNotFoundError:
+        return 404, {"detail": "Article not found"}
+    except (ChannelNotFoundError, ChannelOnWrongProjectError):
+        return 404, {"detail": "Channel not found on this project"}
+    except HeroImageOnWrongProjectError:
+        return 422, {"detail": "Hero image must belong to this project"}
+    return article
+
+
+@router.post(
+    "/{slug}/articles/{article_id}/publish",
+    response={200: ArticleOut, 401: Error, 403: Error, 404: Error, 422: Error},
+    auth=auth,
+    tags=["Articles"],
+)
+def publish_article(
+    request: HttpRequest,
+    slug: str,
+    article_id: UUID,
+    payload: ArticlePublish,
+) -> Article | tuple[int, dict[str, str]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    existing = REPO.articles.get_by_id(article_id)
+    if existing is None or existing.project_id != project.id:
+        return 404, {"detail": "Article not found"}
+    try:
+        article = HANDLERS.articles.publish(
+            article_id, published_at=payload.published_at
+        )
+    except ArticleNotFoundError:
+        return 404, {"detail": "Article not found"}
+    except ArticleNotPublishableError:
+        return 422, {"detail": "Article requires title, body and hero image to publish"}
+    return article
+
+
+@router.delete(
+    "/{slug}/articles/{article_id}",
+    response={204: None, 401: Error, 403: Error, 404: Error},
+    auth=auth,
+    tags=["Articles"],
+)
+def delete_article(
+    request: HttpRequest,
+    slug: str,
+    article_id: UUID,
+) -> tuple[int, None] | tuple[int, dict[str, str]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    existing = REPO.articles.get_by_id(article_id)
+    if existing is None or existing.project_id != project.id:
+        return 404, {"detail": "Article not found"}
+    HANDLERS.articles.delete_article(article_id)
+    return 204, None

--- a/src/django-backend/api/routers/articles.py
+++ b/src/django-backend/api/routers/articles.py
@@ -3,8 +3,12 @@ from uuid import UUID
 from django.http import HttpRequest
 from ninja import Router
 
-from api.auth.jwt import get_user_from_token
 from api.auth.security import auth
+from api.routers._helpers import (
+    get_optional_user,
+    require_full_edit,
+    resolve_visible_project_or_404,
+)
 from api.schemas.article import (
     ArticleCreate,
     ArticleListItem,
@@ -24,16 +28,8 @@ from services.articles.exceptions import (
     ChannelOnWrongProjectError,
     HeroImageOnWrongProjectError,
 )
-from services.project.exceptions import ProjectNotFoundError
 
 router = Router()
-
-
-def _get_optional_user(request: HttpRequest) -> User | None:
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        return get_user_from_token(auth_header[7:])
-    return None
 
 
 def _can_view_draft(article: Article, user: User | None) -> bool:
@@ -44,24 +40,13 @@ def _can_view_draft(article: Article, user: User | None) -> bool:
     return REPO.project.user_can_edit(article.project_id, user.id)
 
 
-def _resolve_project_or_404(
-    slug: str,
-) -> Project | tuple[int, dict[str, str]]:
-    try:
-        return REPO.project.get_by_identifier(slug)
-    except ProjectNotFoundError:
-        return 404, {"detail": "Project not found"}
-
-
-def _require_full_edit(
-    slug: str, user_id: UUID
-) -> Project | tuple[int, dict[str, str]]:
-    resolved = _resolve_project_or_404(slug)
-    if isinstance(resolved, tuple):
-        return resolved
-    if not REPO.project.user_can_edit(resolved.id, user_id):
-        return 403, {"detail": "You don't have edit access to this project"}
-    return resolved
+def _get_article_in_project(
+    project: Project, article_id: UUID
+) -> Article | tuple[int, dict[str, str]]:
+    article = REPO.articles.get_by_id(article_id)
+    if article is None or article.project_id != project.id:
+        return 404, {"detail": "Article not found"}
+    return article
 
 
 @router.post(
@@ -75,7 +60,7 @@ def create_article(
     slug: str,
     payload: ArticleCreate,
 ) -> tuple[int, Article] | tuple[int, dict[str, str]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
     try:
@@ -103,10 +88,10 @@ def list_articles(
     request: HttpRequest,
     slug: str,
 ) -> list[Article] | tuple[int, dict[str, str]]:
-    project = _resolve_project_or_404(slug)
+    user = get_optional_user(request)
+    project = resolve_visible_project_or_404(slug, user)
     if isinstance(project, tuple):
         return project
-    user = _get_optional_user(request)
     include_drafts = user is not None and REPO.project.user_can_edit(
         project.id, user.id
     )
@@ -123,13 +108,15 @@ def get_article_by_slug(
     slug: str,
     article_slug: str,
 ) -> Article | tuple[int, dict[str, str]]:
+    user = get_optional_user(request)
+    project = resolve_visible_project_or_404(slug, user)
+    if isinstance(project, tuple):
+        return project
     article = REPO.articles.get_by_project_and_slug(slug, article_slug)
-    if article is None:
+    if article is None or article.project_id != project.id:
         return 404, {"detail": "Article not found"}
-    if article.state != ArticleState.PUBLISHED:
-        user = _get_optional_user(request)
-        if not _can_view_draft(article, user):
-            return 404, {"detail": "Article not found"}
+    if article.state != ArticleState.PUBLISHED and not _can_view_draft(article, user):
+        return 404, {"detail": "Article not found"}
     return article
 
 
@@ -144,12 +131,12 @@ def get_article(
     slug: str,
     article_id: UUID,
 ) -> Article | tuple[int, dict[str, str]]:
-    project = _resolve_project_or_404(slug)
+    project = resolve_visible_project_or_404(slug, request.auth)
     if isinstance(project, tuple):
         return project
-    article = REPO.articles.get_by_id(article_id)
-    if article is None or article.project_id != project.id:
-        return 404, {"detail": "Article not found"}
+    article = _get_article_in_project(project, article_id)
+    if isinstance(article, tuple):
+        return article
     if article.state != ArticleState.PUBLISHED and not _can_view_draft(
         article, request.auth
     ):
@@ -169,12 +156,12 @@ def patch_article(
     article_id: UUID,
     payload: ArticleUpdate,
 ) -> Article | tuple[int, dict[str, str]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
-    existing = REPO.articles.get_by_id(article_id)
-    if existing is None or existing.project_id != project.id:
-        return 404, {"detail": "Article not found"}
+    existing = _get_article_in_project(project, article_id)
+    if isinstance(existing, tuple):
+        return existing
     try:
         article = HANDLERS.articles.update_article(
             article_id,
@@ -205,12 +192,12 @@ def publish_article(
     article_id: UUID,
     payload: ArticlePublish,
 ) -> Article | tuple[int, dict[str, str]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
-    existing = REPO.articles.get_by_id(article_id)
-    if existing is None or existing.project_id != project.id:
-        return 404, {"detail": "Article not found"}
+    existing = _get_article_in_project(project, article_id)
+    if isinstance(existing, tuple):
+        return existing
     try:
         article = HANDLERS.articles.publish(
             article_id, published_at=payload.published_at
@@ -233,11 +220,11 @@ def delete_article(
     slug: str,
     article_id: UUID,
 ) -> tuple[int, None] | tuple[int, dict[str, str]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
-    existing = REPO.articles.get_by_id(article_id)
-    if existing is None or existing.project_id != project.id:
-        return 404, {"detail": "Article not found"}
+    existing = _get_article_in_project(project, article_id)
+    if isinstance(existing, tuple):
+        return existing
     HANDLERS.articles.delete_article(article_id)
     return 204, None

--- a/src/django-backend/api/routers/channels.py
+++ b/src/django-backend/api/routers/channels.py
@@ -1,0 +1,215 @@
+from uuid import UUID
+
+from django.http import HttpRequest
+from ninja import Router
+
+from api.auth.security import auth
+from api.schemas.article import (
+    ChannelConflictResponse,
+    ChannelCreate,
+    ChannelReassign,
+    ChannelReassignResponse,
+    ChannelRename,
+    ChannelResponse,
+)
+from api.schemas.errors import Error
+from apps.follows.models import Channel
+from apps.projects.models import Project
+from services import HANDLERS, REPO
+from services.articles.exceptions import (
+    ChannelHasArticlesError,
+    ChannelNotFoundError,
+    ChannelOnWrongProjectError,
+    DuplicateChannelNameError,
+    LastChannelError,
+)
+from services.project.exceptions import ProjectNotFoundError
+
+router = Router()
+
+
+def _resolve_project_or_404(
+    slug: str,
+) -> Project | tuple[int, dict[str, str]]:
+    try:
+        return REPO.project.get_by_identifier(slug)
+    except ProjectNotFoundError:
+        return 404, {"detail": "Project not found"}
+
+
+def _require_full_edit(
+    slug: str, user_id: UUID
+) -> Project | tuple[int, dict[str, str]]:
+    resolved = _resolve_project_or_404(slug)
+    if isinstance(resolved, tuple):
+        return resolved
+    if not REPO.project.user_can_edit(resolved.id, user_id):
+        return 403, {"detail": "You don't have edit access to this project"}
+    return resolved
+
+
+@router.get(
+    "/{slug}/channels",
+    response={200: list[ChannelResponse], 404: Error},
+    tags=["Channels"],
+)
+def list_channels(
+    request: HttpRequest,
+    slug: str,
+) -> list[Channel] | tuple[int, dict[str, str]]:
+    project = _resolve_project_or_404(slug)
+    if isinstance(project, tuple):
+        return project
+    return list(REPO.articles.list_channels_for_project(project.id))
+
+
+@router.post(
+    "/{slug}/channels",
+    response={
+        201: ChannelResponse,
+        401: Error,
+        403: Error,
+        404: Error,
+        409: Error,
+    },
+    auth=auth,
+    tags=["Channels"],
+)
+def create_channel(
+    request: HttpRequest,
+    slug: str,
+    payload: ChannelCreate,
+) -> tuple[int, Channel] | tuple[int, dict[str, str]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    try:
+        channel = HANDLERS.articles.add_channel(project.id, payload.name)
+    except DuplicateChannelNameError:
+        return 409, {"detail": "A channel with that name already exists"}
+    return 201, channel
+
+
+@router.patch(
+    "/{slug}/channels/{channel_id}",
+    response={
+        200: ChannelResponse,
+        401: Error,
+        403: Error,
+        404: Error,
+        409: Error,
+    },
+    auth=auth,
+    tags=["Channels"],
+)
+def rename_channel(
+    request: HttpRequest,
+    slug: str,
+    channel_id: UUID,
+    payload: ChannelRename,
+) -> Channel | tuple[int, dict[str, str]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    existing = next(
+        (
+            c
+            for c in REPO.articles.list_channels_for_project(project.id)
+            if c.id == channel_id
+        ),
+        None,
+    )
+    if existing is None:
+        return 404, {"detail": "Channel not found"}
+    try:
+        return HANDLERS.articles.rename_channel(channel_id, payload.name)
+    except ChannelNotFoundError:
+        return 404, {"detail": "Channel not found"}
+    except DuplicateChannelNameError:
+        return 409, {"detail": "A channel with that name already exists"}
+
+
+@router.delete(
+    "/{slug}/channels/{channel_id}",
+    response={
+        204: None,
+        401: Error,
+        403: Error,
+        404: Error,
+        409: ChannelConflictResponse,
+    },
+    auth=auth,
+    tags=["Channels"],
+)
+def delete_channel(
+    request: HttpRequest,
+    slug: str,
+    channel_id: UUID,
+) -> tuple[int, None] | tuple[int, dict[str, object]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    existing = next(
+        (
+            c
+            for c in REPO.articles.list_channels_for_project(project.id)
+            if c.id == channel_id
+        ),
+        None,
+    )
+    if existing is None:
+        return 404, {"detail": "Channel not found"}
+    try:
+        HANDLERS.articles.delete_channel(channel_id)
+    except ChannelNotFoundError:
+        return 404, {"detail": "Channel not found"}
+    except ChannelHasArticlesError as exc:
+        return 409, {
+            "detail": "Channel still has articles",
+            "article_count": exc.article_count,
+        }
+    except LastChannelError:
+        return 409, {
+            "detail": "Cannot delete the last channel on a project",
+            "article_count": None,
+        }
+    return 204, None
+
+
+@router.post(
+    "/{slug}/channels/{channel_id}/reassign",
+    response={
+        200: ChannelReassignResponse,
+        401: Error,
+        403: Error,
+        404: Error,
+        422: Error,
+    },
+    auth=auth,
+    tags=["Channels"],
+)
+def reassign_channel(
+    request: HttpRequest,
+    slug: str,
+    channel_id: UUID,
+    payload: ChannelReassign,
+) -> ChannelReassignResponse | tuple[int, dict[str, str]]:
+    project = _require_full_edit(slug, request.auth.id)
+    if isinstance(project, tuple):
+        return project
+    channels_on_project = {
+        c.id: c for c in REPO.articles.list_channels_for_project(project.id)
+    }
+    if channel_id not in channels_on_project:
+        return 404, {"detail": "Channel not found"}
+    if payload.target_channel_id not in channels_on_project:
+        return 422, {"detail": "Target channel must belong to the same project"}
+    try:
+        reassigned = HANDLERS.articles.bulk_reassign_articles(
+            channel_id, payload.target_channel_id
+        )
+    except ChannelNotFoundError:
+        return 404, {"detail": "Channel not found"}
+    except ChannelOnWrongProjectError:
+        return 422, {"detail": "Target channel must belong to the same project"}
+    return ChannelReassignResponse(reassigned=reassigned)

--- a/src/django-backend/api/routers/channels.py
+++ b/src/django-backend/api/routers/channels.py
@@ -4,7 +4,12 @@ from django.http import HttpRequest
 from ninja import Router
 
 from api.auth.security import auth
-from api.schemas.article import (
+from api.routers._helpers import (
+    get_optional_user,
+    require_full_edit,
+    resolve_visible_project_or_404,
+)
+from api.schemas.channel import (
     ChannelConflictResponse,
     ChannelCreate,
     ChannelReassign,
@@ -14,7 +19,6 @@ from api.schemas.article import (
 )
 from api.schemas.errors import Error
 from apps.follows.models import Channel
-from apps.projects.models import Project
 from services import HANDLERS, REPO
 from services.articles.exceptions import (
     ChannelHasArticlesError,
@@ -23,29 +27,8 @@ from services.articles.exceptions import (
     DuplicateChannelNameError,
     LastChannelError,
 )
-from services.project.exceptions import ProjectNotFoundError
 
 router = Router()
-
-
-def _resolve_project_or_404(
-    slug: str,
-) -> Project | tuple[int, dict[str, str]]:
-    try:
-        return REPO.project.get_by_identifier(slug)
-    except ProjectNotFoundError:
-        return 404, {"detail": "Project not found"}
-
-
-def _require_full_edit(
-    slug: str, user_id: UUID
-) -> Project | tuple[int, dict[str, str]]:
-    resolved = _resolve_project_or_404(slug)
-    if isinstance(resolved, tuple):
-        return resolved
-    if not REPO.project.user_can_edit(resolved.id, user_id):
-        return 403, {"detail": "You don't have edit access to this project"}
-    return resolved
 
 
 @router.get(
@@ -57,7 +40,8 @@ def list_channels(
     request: HttpRequest,
     slug: str,
 ) -> list[Channel] | tuple[int, dict[str, str]]:
-    project = _resolve_project_or_404(slug)
+    user = get_optional_user(request)
+    project = resolve_visible_project_or_404(slug, user)
     if isinstance(project, tuple):
         return project
     return list(REPO.articles.list_channels_for_project(project.id))
@@ -80,7 +64,7 @@ def create_channel(
     slug: str,
     payload: ChannelCreate,
 ) -> tuple[int, Channel] | tuple[int, dict[str, str]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
     try:
@@ -108,18 +92,10 @@ def rename_channel(
     channel_id: UUID,
     payload: ChannelRename,
 ) -> Channel | tuple[int, dict[str, str]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
-    existing = next(
-        (
-            c
-            for c in REPO.articles.list_channels_for_project(project.id)
-            if c.id == channel_id
-        ),
-        None,
-    )
-    if existing is None:
+    if REPO.articles.get_channel_in_project(project.id, channel_id) is None:
         return 404, {"detail": "Channel not found"}
     try:
         return HANDLERS.articles.rename_channel(channel_id, payload.name)
@@ -146,18 +122,10 @@ def delete_channel(
     slug: str,
     channel_id: UUID,
 ) -> tuple[int, None] | tuple[int, dict[str, object]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
-    existing = next(
-        (
-            c
-            for c in REPO.articles.list_channels_for_project(project.id)
-            if c.id == channel_id
-        ),
-        None,
-    )
-    if existing is None:
+    if REPO.articles.get_channel_in_project(project.id, channel_id) is None:
         return 404, {"detail": "Channel not found"}
     try:
         HANDLERS.articles.delete_channel(channel_id)
@@ -194,15 +162,15 @@ def reassign_channel(
     channel_id: UUID,
     payload: ChannelReassign,
 ) -> ChannelReassignResponse | tuple[int, dict[str, str]]:
-    project = _require_full_edit(slug, request.auth.id)
+    project = require_full_edit(slug, request.auth.id)
     if isinstance(project, tuple):
         return project
-    channels_on_project = {
-        c.id: c for c in REPO.articles.list_channels_for_project(project.id)
-    }
-    if channel_id not in channels_on_project:
+    if REPO.articles.get_channel_in_project(project.id, channel_id) is None:
         return 404, {"detail": "Channel not found"}
-    if payload.target_channel_id not in channels_on_project:
+    if (
+        REPO.articles.get_channel_in_project(project.id, payload.target_channel_id)
+        is None
+    ):
         return 422, {"detail": "Target channel must belong to the same project"}
     try:
         reassigned = HANDLERS.articles.bulk_reassign_articles(

--- a/src/django-backend/api/routers/notifications.py
+++ b/src/django-backend/api/routers/notifications.py
@@ -59,11 +59,15 @@ def mark_thread_read(
         marked = HANDLERS.notifications.mark_thread_read_for_user(
             request.auth.id, payload.root_discussion_id
         )
-    else:
-        # validator on MarkThreadReadRequest guarantees comment_id is set here
+    elif payload.comment_id is not None:
         marked = HANDLERS.notifications.mark_thread_read_for_comment(
+            request.auth.id, payload.comment_id
+        )
+    else:
+        # validator on MarkThreadReadRequest guarantees article_id is set here
+        marked = HANDLERS.notifications.mark_article_read_for_user(
             request.auth.id,
-            payload.comment_id,  # type: ignore[arg-type]
+            payload.article_id,  # type: ignore[arg-type]
         )
     return MarkThreadReadResponse(marked=marked)
 

--- a/src/django-backend/api/routers/projects.py
+++ b/src/django-backend/api/routers/projects.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from django.http import HttpRequest
 from ninja import Query, Router
 
-from api.auth.jwt import get_user_from_token
+from api.routers._helpers import get_optional_user
 from api.schemas.errors import Error
 from api.schemas.project import (
     CategoryResponse,
@@ -16,9 +16,6 @@ from api.schemas.project import (
 from apps.projects.models import Project, ProjectStatus
 from services import REPO
 from services.project.exceptions import ProjectNotFoundError
-
-if TYPE_CHECKING:
-    from apps.users.models import User
 
 router = Router()
 
@@ -165,14 +162,6 @@ def list_projects(
     }
 
 
-def _get_user_from_request(request: HttpRequest) -> "User | None":
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        token = auth_header[7:]
-        return get_user_from_token(token)
-    return None
-
-
 @router.get(
     "/{identifier}",
     response={200: ProjectResponse, 404: Error},
@@ -187,7 +176,7 @@ def get_project(
     except ProjectNotFoundError:
         return 404, {"detail": "Project not found"}
 
-    user = _get_user_from_request(request)
+    user = get_optional_user(request)
     user_id = user.id if user else None
     project.is_followed = REPO.follows.is_followed(user_id, project)
 

--- a/src/django-backend/api/routers/test_articles.py
+++ b/src/django-backend/api/routers/test_articles.py
@@ -4,6 +4,7 @@ import pytest
 from hamcrest import assert_that, equal_to, has_entries, has_length
 
 from apps.articles.models import Article, ArticleState
+from apps.projects.models import ProjectStatus
 from tests.factories import (
     ArticleFactory,
     ChannelFactory,
@@ -129,7 +130,7 @@ class TestCreateArticle:
 @pytest.mark.django_db
 class TestListArticles:
     def test_anonymous_sees_only_published(self, client) -> None:
-        project = ProjectFactory()
+        project = ProjectFactory(status=ProjectStatus.APPROVED)
         PublishedArticleFactory(project=project, title="Pub")
         ArticleFactory(project=project, title="Draft")
 
@@ -153,6 +154,22 @@ class TestListArticles:
         response = client.get("/api/projects/does-not-exist/articles")
         assert_that(response.status_code, equal_to(404))
 
+    def test_pending_project_404s_for_anonymous(self, client) -> None:
+        project = ProjectFactory(status=ProjectStatus.PENDING)
+        PublishedArticleFactory(project=project, title="Pub")
+
+        response = client.get(f"/api/projects/{project.id}/articles")
+
+        assert_that(response.status_code, equal_to(404))
+
+    def test_pending_project_404s_for_non_editor(self, client, auth_headers) -> None:
+        project = ProjectFactory(status=ProjectStatus.PENDING)
+        PublishedArticleFactory(project=project, title="Pub")
+
+        response = client.get(f"/api/projects/{project.id}/articles", **auth_headers)
+
+        assert_that(response.status_code, equal_to(404))
+
 
 @pytest.mark.django_db
 class TestGetArticleById:
@@ -163,7 +180,7 @@ class TestGetArticleById:
         assert_that(response.status_code, equal_to(401))
 
     def test_published_visible_to_any_authed_user(self, client, auth_headers) -> None:
-        project = ProjectFactory()
+        project = ProjectFactory(status=ProjectStatus.APPROVED)
         article = PublishedArticleFactory(project=project)
         response = client.get(
             f"/api/projects/{project.id}/articles/{article.id}",
@@ -175,13 +192,24 @@ class TestGetArticleById:
     def test_draft_returns_403_for_non_author_non_full_edit(
         self, client, auth_headers
     ) -> None:
-        project = ProjectFactory()  # creator is a different user
+        project = ProjectFactory(status=ProjectStatus.APPROVED)
         draft = ArticleFactory(project=project)
         response = client.get(
             f"/api/projects/{project.id}/articles/{draft.id}",
             **auth_headers,
         )
         assert_that(response.status_code, equal_to(403))
+
+    def test_pending_project_404s_for_authed_non_editor(
+        self, client, auth_headers
+    ) -> None:
+        project = ProjectFactory(status=ProjectStatus.PENDING)
+        article = PublishedArticleFactory(project=project)
+        response = client.get(
+            f"/api/projects/{project.id}/articles/{article.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
 
     def test_draft_visible_to_author(self, client, user, auth_headers) -> None:
         project = ProjectFactory(owner=user)
@@ -206,7 +234,7 @@ class TestGetArticleById:
         assert_that(response.status_code, equal_to(404))
 
     def test_unknown_article_returns_404(self, client, auth_headers) -> None:
-        project = ProjectFactory()
+        project = ProjectFactory(status=ProjectStatus.APPROVED)
         fake = "00000000-0000-0000-0000-000000000000"
         response = client.get(
             f"/api/projects/{project.id}/articles/{fake}", **auth_headers
@@ -217,7 +245,7 @@ class TestGetArticleById:
 @pytest.mark.django_db
 class TestGetArticleBySlug:
     def test_published_visible_to_anonymous(self, client) -> None:
-        project = ProjectFactory(slug="my-proj")
+        project = ProjectFactory(slug="my-proj", status=ProjectStatus.APPROVED)
         article = PublishedArticleFactory(project=project, title="X")
         article.slug = "x"
         article.save(update_fields=["slug"])
@@ -228,7 +256,7 @@ class TestGetArticleBySlug:
         assert_that(response.json(), has_entries(id=str(article.id)))
 
     def test_draft_404s_for_anonymous(self, client) -> None:
-        project = ProjectFactory(slug="my-proj")
+        project = ProjectFactory(slug="my-proj", status=ProjectStatus.APPROVED)
         draft = ArticleFactory(project=project)
         draft.slug = "draft-slug"
         draft.save(update_fields=["slug"])
@@ -249,8 +277,18 @@ class TestGetArticleBySlug:
         assert_that(response.status_code, equal_to(200))
 
     def test_unknown_slug_returns_404(self, client) -> None:
-        ProjectFactory(slug="my-proj")
+        ProjectFactory(slug="my-proj", status=ProjectStatus.APPROVED)
         response = client.get("/api/projects/my-proj/articles/by-slug/missing")
+        assert_that(response.status_code, equal_to(404))
+
+    def test_pending_project_404s_for_anonymous(self, client) -> None:
+        project = ProjectFactory(slug="my-proj", status=ProjectStatus.PENDING)
+        article = PublishedArticleFactory(project=project, title="X")
+        article.slug = "x"
+        article.save(update_fields=["slug"])
+
+        response = client.get("/api/projects/my-proj/articles/by-slug/x")
+
         assert_that(response.status_code, equal_to(404))
 
 

--- a/src/django-backend/api/routers/test_articles.py
+++ b/src/django-backend/api/routers/test_articles.py
@@ -1,0 +1,434 @@
+from pathlib import Path
+
+import pytest
+from hamcrest import assert_that, equal_to, has_entries, has_length
+
+from apps.articles.models import Article, ArticleState
+from tests.factories import (
+    ArticleFactory,
+    ChannelFactory,
+    ProjectFactory,
+    ProjectImageFactory,
+    PublishedArticleFactory,
+)
+
+
+def _post(client, url, payload, headers=None):
+    return client.post(
+        url,
+        data=payload,
+        content_type="application/json",
+        **(headers or {}),
+    )
+
+
+def _patch(client, url, payload, headers=None):
+    return client.patch(
+        url,
+        data=payload,
+        content_type="application/json",
+        **(headers or {}),
+    )
+
+
+@pytest.mark.django_db
+class TestCreateArticle:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        channel = ChannelFactory(project=project, name="Updates")
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles",
+            {"channel_id": str(channel.id)},
+        )
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_contributor_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()  # creator is a different user
+        channel = ChannelFactory(project=project, name="Updates")
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles",
+            {"channel_id": str(channel.id)},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_unknown_project_returns_404(self, client, auth_headers) -> None:
+        response = _post(
+            client,
+            "/api/projects/does-not-exist/articles",
+            {"channel_id": "00000000-0000-0000-0000-000000000000"},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+    def test_owner_can_create_draft(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        channel = ChannelFactory(project=project, name="Updates")
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles",
+            {
+                "channel_id": str(channel.id),
+                "title": "First article",
+                "body": "Body text",
+            },
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(201))
+        assert_that(
+            response.json(),
+            has_entries(
+                title="First article",
+                body="Body text",
+                state="draft",
+                channel=has_entries(id=str(channel.id), name="Updates"),
+                project=has_entries(id=str(project.id)),
+                author=has_entries(id=str(user.id)),
+            ),
+        )
+        assert Article.objects.filter(project=project).count() == 1
+
+    def test_channel_on_wrong_project_returns_404(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        other_project = ProjectFactory()
+        foreign_channel = ChannelFactory(project=other_project, name="Updates")
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles",
+            {"channel_id": str(foreign_channel.id)},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+    def test_hero_image_on_wrong_project_returns_422(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        channel = ChannelFactory(project=project, name="Updates")
+        foreign_image = ProjectImageFactory()  # belongs to a different project
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles",
+            {
+                "channel_id": str(channel.id),
+                "hero_image_id": str(foreign_image.id),
+            },
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(422))
+
+
+@pytest.mark.django_db
+class TestListArticles:
+    def test_anonymous_sees_only_published(self, client) -> None:
+        project = ProjectFactory()
+        PublishedArticleFactory(project=project, title="Pub")
+        ArticleFactory(project=project, title="Draft")
+
+        response = client.get(f"/api/projects/{project.id}/articles")
+
+        assert_that(response.status_code, equal_to(200))
+        titles = [a["title"] for a in response.json()]
+        assert_that(titles, equal_to(["Pub"]))
+
+    def test_full_edit_user_sees_drafts_too(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        PublishedArticleFactory(project=project, title="Pub")
+        ArticleFactory(project=project, title="Draft")
+
+        response = client.get(f"/api/projects/{project.id}/articles", **auth_headers)
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.json(), has_length(2))
+
+    def test_unknown_project_returns_404(self, client) -> None:
+        response = client.get("/api/projects/does-not-exist/articles")
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestGetArticleById:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        article = PublishedArticleFactory(project=project)
+        response = client.get(f"/api/projects/{project.id}/articles/{article.id}")
+        assert_that(response.status_code, equal_to(401))
+
+    def test_published_visible_to_any_authed_user(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        article = PublishedArticleFactory(project=project)
+        response = client.get(
+            f"/api/projects/{project.id}/articles/{article.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.json(), has_entries(id=str(article.id)))
+
+    def test_draft_returns_403_for_non_author_non_full_edit(
+        self, client, auth_headers
+    ) -> None:
+        project = ProjectFactory()  # creator is a different user
+        draft = ArticleFactory(project=project)
+        response = client.get(
+            f"/api/projects/{project.id}/articles/{draft.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_draft_visible_to_author(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        draft = ArticleFactory(project=project, author=user)
+        response = client.get(
+            f"/api/projects/{project.id}/articles/{draft.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(200))
+
+    def test_article_on_different_project_returns_404(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        other_project = ProjectFactory()
+        article = PublishedArticleFactory(project=other_project)
+
+        response = client.get(
+            f"/api/projects/{project.id}/articles/{article.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+    def test_unknown_article_returns_404(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        fake = "00000000-0000-0000-0000-000000000000"
+        response = client.get(
+            f"/api/projects/{project.id}/articles/{fake}", **auth_headers
+        )
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestGetArticleBySlug:
+    def test_published_visible_to_anonymous(self, client) -> None:
+        project = ProjectFactory(slug="my-proj")
+        article = PublishedArticleFactory(project=project, title="X")
+        article.slug = "x"
+        article.save(update_fields=["slug"])
+
+        response = client.get("/api/projects/my-proj/articles/by-slug/x")
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.json(), has_entries(id=str(article.id)))
+
+    def test_draft_404s_for_anonymous(self, client) -> None:
+        project = ProjectFactory(slug="my-proj")
+        draft = ArticleFactory(project=project)
+        draft.slug = "draft-slug"
+        draft.save(update_fields=["slug"])
+
+        response = client.get("/api/projects/my-proj/articles/by-slug/draft-slug")
+        assert_that(response.status_code, equal_to(404))
+
+    def test_draft_visible_to_author(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user, slug="my-proj")
+        draft = ArticleFactory(project=project, author=user)
+        draft.slug = "draft-slug"
+        draft.save(update_fields=["slug"])
+
+        response = client.get(
+            "/api/projects/my-proj/articles/by-slug/draft-slug",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(200))
+
+    def test_unknown_slug_returns_404(self, client) -> None:
+        ProjectFactory(slug="my-proj")
+        response = client.get("/api/projects/my-proj/articles/by-slug/missing")
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestPatchArticle:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        article = ArticleFactory(project=project)
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}",
+            {"title": "New"},
+        )
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_full_edit_user_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()  # creator is someone else
+        article = ArticleFactory(project=project)
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}",
+            {"title": "New"},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_owner_can_update_title(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        article = ArticleFactory(project=project)
+
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}",
+            {"title": "Updated"},
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(200))
+        article.refresh_from_db()
+        assert_that(article.title, equal_to("Updated"))
+
+    def test_article_on_different_project_returns_404(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        other = ProjectFactory()
+        article = ArticleFactory(project=other)
+
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}",
+            {"title": "Updated"},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestPublishArticle:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        article = ArticleFactory(project=project)
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}/publish",
+            {},
+        )
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_full_edit_user_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        article = ArticleFactory(project=project)
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}/publish",
+            {},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_owner_can_publish(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        article = ArticleFactory(project=project)
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}/publish",
+            {},
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(200))
+        article.refresh_from_db()
+        assert_that(article.state, equal_to(ArticleState.PUBLISHED))
+        assert article.slug  # slug assigned on publish
+
+    def test_publish_without_body_returns_422(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        article = ArticleFactory(project=project, body="")
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles/{article.id}/publish",
+            {},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(422))
+
+    def test_unknown_article_returns_404(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        fake = "00000000-0000-0000-0000-000000000000"
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/articles/{fake}/publish",
+            {},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestDeleteArticle:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        article = ArticleFactory(project=project)
+        response = client.delete(f"/api/projects/{project.id}/articles/{article.id}")
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_full_edit_user_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        article = ArticleFactory(project=project)
+        response = client.delete(
+            f"/api/projects/{project.id}/articles/{article.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_owner_can_delete(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        article = ArticleFactory(project=project)
+
+        response = client.delete(
+            f"/api/projects/{project.id}/articles/{article.id}",
+            **auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(204))
+        assert not Article.objects.filter(pk=article.id).exists()
+
+    def test_article_on_different_project_returns_404(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        other = ProjectFactory()
+        article = ArticleFactory(project=other)
+
+        response = client.delete(
+            f"/api/projects/{project.id}/articles/{article.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestRouterHasNoOrmAccess:
+    """Spec invariant — `api/routers/articles.py` SHALL NOT reference
+    `Article.objects`, `Channel.objects`, or `FollowChannelPreference.objects`
+    directly. All DB access goes through HANDLERS / REPO.
+    """
+
+    def test_no_orm_imports(self) -> None:
+        src = Path(__file__).resolve().parent.parent / "routers" / "articles.py"
+        text = src.read_text()
+        for forbidden in (
+            "Article.objects",
+            "Channel.objects",
+            "FollowChannelPreference.objects",
+        ):
+            assert forbidden not in text, (
+                f"{forbidden} must not appear in api/routers/articles.py"
+            )

--- a/src/django-backend/api/routers/test_channels.py
+++ b/src/django-backend/api/routers/test_channels.py
@@ -5,6 +5,7 @@ from hamcrest import assert_that, equal_to, has_entries, has_length
 
 from apps.articles.models import Article
 from apps.follows.models import Channel
+from apps.projects.models import ProjectStatus
 from tests.factories import (
     ArticleFactory,
     ChannelFactory,
@@ -33,9 +34,8 @@ def _patch(client, url, payload, headers=None):
 @pytest.mark.django_db
 class TestListChannels:
     def test_anonymous_can_list(self, client) -> None:
-        project = ProjectFactory()
+        project = ProjectFactory(status=ProjectStatus.APPROVED)
         ChannelFactory(project=project, name="News")
-        # Project creation auto-seeds an "Updates" channel.
 
         response = client.get(f"/api/projects/{project.id}/channels")
 
@@ -46,6 +46,32 @@ class TestListChannels:
     def test_unknown_project_returns_404(self, client) -> None:
         response = client.get("/api/projects/does-not-exist/channels")
         assert_that(response.status_code, equal_to(404))
+
+    def test_pending_project_404s_for_anonymous(self, client) -> None:
+        project = ProjectFactory(status=ProjectStatus.PENDING)
+        ChannelFactory(project=project, name="News")
+
+        response = client.get(f"/api/projects/{project.id}/channels")
+
+        assert_that(response.status_code, equal_to(404))
+
+    def test_pending_project_404s_for_non_editor(self, client, auth_headers) -> None:
+        project = ProjectFactory(status=ProjectStatus.PENDING)
+        ChannelFactory(project=project, name="News")
+
+        response = client.get(f"/api/projects/{project.id}/channels", **auth_headers)
+
+        assert_that(response.status_code, equal_to(404))
+
+    def test_editor_can_list_on_pending_project(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user, status=ProjectStatus.PENDING)
+        ChannelFactory(project=project, name="News")
+
+        response = client.get(f"/api/projects/{project.id}/channels", **auth_headers)
+
+        assert_that(response.status_code, equal_to(200))
 
 
 @pytest.mark.django_db

--- a/src/django-backend/api/routers/test_channels.py
+++ b/src/django-backend/api/routers/test_channels.py
@@ -1,0 +1,321 @@
+from pathlib import Path
+
+import pytest
+from hamcrest import assert_that, equal_to, has_entries, has_length
+
+from apps.articles.models import Article
+from apps.follows.models import Channel
+from tests.factories import (
+    ArticleFactory,
+    ChannelFactory,
+    ProjectFactory,
+)
+
+
+def _post(client, url, payload, headers=None):
+    return client.post(
+        url,
+        data=payload,
+        content_type="application/json",
+        **(headers or {}),
+    )
+
+
+def _patch(client, url, payload, headers=None):
+    return client.patch(
+        url,
+        data=payload,
+        content_type="application/json",
+        **(headers or {}),
+    )
+
+
+@pytest.mark.django_db
+class TestListChannels:
+    def test_anonymous_can_list(self, client) -> None:
+        project = ProjectFactory()
+        ChannelFactory(project=project, name="News")
+        # Project creation auto-seeds an "Updates" channel.
+
+        response = client.get(f"/api/projects/{project.id}/channels")
+
+        assert_that(response.status_code, equal_to(200))
+        names = sorted(c["name"] for c in response.json())
+        assert_that(names, equal_to(["News", "Updates"]))
+
+    def test_unknown_project_returns_404(self, client) -> None:
+        response = client.get("/api/projects/does-not-exist/channels")
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestCreateChannel:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels",
+            {"name": "Press"},
+        )
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_full_edit_user_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels",
+            {"name": "Press"},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_owner_can_create(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels",
+            {"name": "Press"},
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(201))
+        assert_that(response.json(), has_entries(name="Press"))
+        assert Channel.objects.filter(project=project, name="Press").exists()
+
+    def test_duplicate_name_returns_409(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        ChannelFactory(project=project, name="Press")
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels",
+            {"name": "Press"},
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(409))
+
+
+@pytest.mark.django_db
+class TestRenameChannel:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        channel = ChannelFactory(project=project, name="News")
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            {"name": "Press"},
+        )
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_full_edit_user_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        channel = ChannelFactory(project=project, name="News")
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            {"name": "Press"},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_owner_can_rename(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        channel = ChannelFactory(project=project, name="News")
+
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            {"name": "Press"},
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.json(), has_entries(name="Press"))
+        channel.refresh_from_db()
+        assert_that(channel.name, equal_to("Press"))
+
+    def test_duplicate_name_returns_409(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        ChannelFactory(project=project, name="Press")
+        channel = ChannelFactory(project=project, name="News")
+
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            {"name": "Press"},
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(409))
+
+    def test_channel_on_other_project_returns_404(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        other = ProjectFactory()
+        foreign = ChannelFactory(project=other, name="News")
+
+        response = _patch(
+            client,
+            f"/api/projects/{project.id}/channels/{foreign.id}",
+            {"name": "Press"},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestDeleteChannel:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        channel = ChannelFactory(project=project, name="News")
+        response = client.delete(f"/api/projects/{project.id}/channels/{channel.id}")
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_full_edit_user_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        channel = ChannelFactory(project=project, name="News")
+        response = client.delete(
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            **auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_owner_can_delete_empty_non_last_channel(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        channel = ChannelFactory(project=project, name="News")
+        # "Updates" is also present from project auto-seed.
+
+        response = client.delete(
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            **auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(204))
+        assert not Channel.objects.filter(pk=channel.id).exists()
+
+    def test_delete_channel_with_articles_returns_409(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        channel = ChannelFactory(project=project, name="News")
+        ArticleFactory(project=project, channel=channel)
+
+        response = client.delete(
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            **auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(409))
+        assert_that(response.json(), has_entries(article_count=1))
+
+    def test_delete_only_channel_returns_409(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        # Drop the auto-seeded sibling to leave one channel.
+        Channel.objects.filter(project=project).exclude(name="Updates").delete()
+        channel = Channel.objects.get(project=project, name="Updates")
+
+        response = client.delete(
+            f"/api/projects/{project.id}/channels/{channel.id}",
+            **auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(409))
+
+
+@pytest.mark.django_db
+class TestReassignChannel:
+    def test_unauthenticated_returns_401(self, client) -> None:
+        project = ProjectFactory()
+        src = ChannelFactory(project=project, name="News")
+        tgt = ChannelFactory(project=project, name="Updates")
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels/{src.id}/reassign",
+            {"target_channel_id": str(tgt.id)},
+        )
+        assert_that(response.status_code, equal_to(401))
+
+    def test_non_full_edit_user_returns_403(self, client, auth_headers) -> None:
+        project = ProjectFactory()
+        src = ChannelFactory(project=project, name="News")
+        tgt = ChannelFactory(project=project, name="Updates")
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels/{src.id}/reassign",
+            {"target_channel_id": str(tgt.id)},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(403))
+
+    def test_owner_can_reassign(self, client, user, auth_headers) -> None:
+        project = ProjectFactory(owner=user)
+        src = ChannelFactory(project=project, name="News")
+        tgt = ChannelFactory(project=project, name="Updates")
+        ArticleFactory(project=project, channel=src)
+        ArticleFactory(project=project, channel=src)
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels/{src.id}/reassign",
+            {"target_channel_id": str(tgt.id)},
+            auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.json(), has_entries(reassigned=2))
+        assert_that(Article.objects.filter(channel=src), has_length(0))
+        assert_that(Article.objects.filter(channel=tgt), has_length(2))
+
+    def test_target_on_other_project_returns_422(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        src = ChannelFactory(project=project, name="News")
+        other = ProjectFactory()
+        foreign_tgt = ChannelFactory(project=other, name="Updates")
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels/{src.id}/reassign",
+            {"target_channel_id": str(foreign_tgt.id)},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(422))
+
+    def test_source_on_other_project_returns_404(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory(owner=user)
+        tgt = ChannelFactory(project=project, name="Updates")
+        other = ProjectFactory()
+        foreign_src = ChannelFactory(project=other, name="News")
+
+        response = _post(
+            client,
+            f"/api/projects/{project.id}/channels/{foreign_src.id}/reassign",
+            {"target_channel_id": str(tgt.id)},
+            auth_headers,
+        )
+        assert_that(response.status_code, equal_to(404))
+
+
+@pytest.mark.django_db
+class TestRouterHasNoOrmAccess:
+    """Spec invariant — no direct ORM access in api/routers/channels.py."""
+
+    def test_no_orm_imports(self) -> None:
+        src = Path(__file__).resolve().parent.parent / "routers" / "channels.py"
+        text = src.read_text()
+        for forbidden in (
+            "Article.objects",
+            "Channel.objects",
+            "FollowChannelPreference.objects",
+        ):
+            assert forbidden not in text, (
+                f"{forbidden} must not appear in api/routers/channels.py"
+            )

--- a/src/django-backend/api/routers/test_notifications.py
+++ b/src/django-backend/api/routers/test_notifications.py
@@ -8,6 +8,7 @@ from tests.factories import (
     DiscussionFactory,
     NotificationFactory,
     ProjectFactory,
+    PublishedArticleFactory,
 )
 
 
@@ -72,6 +73,7 @@ class TestGroupsEndpoint:
         assert_that(
             data[0],
             has_entries(
+                kind="discussion",
                 root_discussion_id=str(root.id),
                 unread_count=2,
                 headline_kind="replied",
@@ -159,6 +161,149 @@ class TestMarkThreadReadEndpoint:
             )
         )
         assert_that(unread_recipients, equal_to({other_user.id}))
+
+
+@pytest.mark.django_db
+class TestGroupsEndpointArticleKind:
+    def test_article_group_includes_kind_and_metadata(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory()
+        article = PublishedArticleFactory(
+            project=project, title="Spring update", body="Body."
+        )
+        article.slug = "spring-update"
+        article.save(update_fields=["slug"])
+        NotificationFactory(recipient=user, discussion=None, article=article)
+
+        response = client.get("/api/notifications/groups", **auth_headers)
+
+        assert_that(response.status_code, equal_to(200))
+        data = response.json()
+        assert_that(data, has_length(1))
+        assert_that(
+            data[0],
+            has_entries(
+                kind="article",
+                article_id=str(article.id),
+                article_slug="spring-update",
+                article_title="Spring update",
+                channel_name=article.channel.name,
+                unread_count=1,
+                root_discussion_id=None,
+            ),
+        )
+
+    def test_mixed_groups_returned(self, client, user, auth_headers) -> None:
+        project_a = ProjectFactory()
+        project_b = ProjectFactory()
+        discussion = DiscussionFactory(project=project_a)
+        article = PublishedArticleFactory(project=project_b, title="News")
+        article.slug = "news"
+        article.save(update_fields=["slug"])
+        NotificationFactory(recipient=user, discussion=discussion)
+        NotificationFactory(recipient=user, discussion=None, article=article)
+
+        response = client.get("/api/notifications/groups", **auth_headers)
+
+        kinds = sorted(g["kind"] for g in response.json())
+        assert_that(kinds, equal_to(["article", "discussion"]))
+
+    def test_summary_counts_both_kinds(self, client, user, auth_headers) -> None:
+        project_a = ProjectFactory()
+        project_b = ProjectFactory()
+        discussion = DiscussionFactory(project=project_a)
+        article = PublishedArticleFactory(project=project_b)
+        NotificationFactory(recipient=user, discussion=discussion)
+        NotificationFactory(recipient=user, discussion=None, article=article)
+
+        response = client.get("/api/notifications/summary", **auth_headers)
+
+        assert_that(
+            response.json(),
+            equal_to({"has_unread": True, "unread_group_count": 2}),
+        )
+
+
+@pytest.mark.django_db
+class TestMarkThreadReadByArticle:
+    def test_marks_article_notification(self, client, user, auth_headers) -> None:
+        project = ProjectFactory()
+        article = PublishedArticleFactory(project=project)
+        NotificationFactory(recipient=user, discussion=None, article=article)
+
+        response = client.post(
+            "/api/notifications/mark-thread-read",
+            data=json.dumps({"article_id": str(article.id)}),
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.json(), equal_to({"marked": 1}))
+
+    def test_scoped_to_caller(self, client, user, other_user, auth_headers) -> None:
+        from apps.notifications.models import Notification  # noqa: PLC0415
+
+        project = ProjectFactory()
+        article = PublishedArticleFactory(project=project)
+        NotificationFactory(recipient=user, discussion=None, article=article)
+        NotificationFactory(recipient=other_user, discussion=None, article=article)
+
+        client.post(
+            "/api/notifications/mark-thread-read",
+            data=json.dumps({"article_id": str(article.id)}),
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        unread_recipients = set(
+            Notification.objects.filter(in_app_read_at__isnull=True).values_list(
+                "recipient_id", flat=True
+            )
+        )
+        assert_that(unread_recipients, equal_to({other_user.id}))
+
+    def test_rejects_article_id_with_root_discussion_id(
+        self, client, user, auth_headers
+    ) -> None:
+        project = ProjectFactory()
+        article = PublishedArticleFactory(project=project)
+        discussion = DiscussionFactory(project=project)
+
+        response = client.post(
+            "/api/notifications/mark-thread-read",
+            data=json.dumps(
+                {
+                    "article_id": str(article.id),
+                    "root_discussion_id": str(discussion.id),
+                }
+            ),
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(422))
+
+    def test_rejects_all_three_fields(self, client, user, auth_headers) -> None:
+        project = ProjectFactory()
+        article = PublishedArticleFactory(project=project)
+        discussion = DiscussionFactory(project=project)
+
+        response = client.post(
+            "/api/notifications/mark-thread-read",
+            data=json.dumps(
+                {
+                    "article_id": str(article.id),
+                    "root_discussion_id": str(discussion.id),
+                    "comment_id": str(discussion.id),
+                }
+            ),
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert_that(response.status_code, equal_to(422))
 
 
 @pytest.mark.django_db

--- a/src/django-backend/api/schemas/article.py
+++ b/src/django-backend/api/schemas/article.py
@@ -1,0 +1,131 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from ninja import Schema
+
+from .user import PublicUserProfile
+
+
+class ArticleCreate(Schema):
+    channel_id: UUID
+    title: str = ""
+    body: str = ""
+    hero_image_id: UUID | None = None
+
+
+class ArticleUpdate(Schema):
+    title: str | None = None
+    body: str | None = None
+    hero_image_id: UUID | None = None
+    channel_id: UUID | None = None
+    published_at: datetime | None = None
+
+
+class ArticlePublish(Schema):
+    published_at: datetime | None = None
+
+
+class ArticleProjectRef(Schema):
+    id: UUID
+    slug: str | None
+    title: str
+
+
+class ArticleChannelRef(Schema):
+    id: UUID
+    name: str
+
+
+class ArticleOut(Schema):
+    id: UUID
+    project: ArticleProjectRef
+    channel: ArticleChannelRef
+    author: PublicUserProfile | None
+    title: str
+    body: str
+    hero_image_id: UUID | None
+    hero_image_url: str | None
+    slug: str | None
+    source: str
+    external_url: str | None
+    state: str
+    published_at: datetime | None
+    global_visibility: str
+    is_globally_visible: bool
+    created_at: datetime
+    updated_at: datetime
+
+    @staticmethod
+    def resolve_project(obj: Any) -> dict[str, Any]:
+        project = obj.project
+        return {"id": project.id, "slug": project.slug, "title": project.title}
+
+    @staticmethod
+    def resolve_channel(obj: Any) -> dict[str, Any]:
+        channel = obj.channel
+        return {"id": channel.id, "name": channel.name}
+
+    @staticmethod
+    def resolve_hero_image_id(obj: Any) -> UUID | None:
+        return obj.hero_image_id
+
+    @staticmethod
+    def resolve_hero_image_url(obj: Any) -> str | None:
+        hero = obj.hero_image
+        if hero is None:
+            return None
+        return hero.url
+
+    @staticmethod
+    def resolve_is_globally_visible(obj: Any) -> bool:
+        return obj.is_globally_visible
+
+
+class ChannelCreate(Schema):
+    name: str
+
+
+class ChannelRename(Schema):
+    name: str
+
+
+class ChannelReassign(Schema):
+    target_channel_id: UUID
+
+
+class ChannelResponse(Schema):
+    id: UUID
+    name: str
+
+
+class ChannelReassignResponse(Schema):
+    reassigned: int
+
+
+class ChannelConflictResponse(Schema):
+    detail: str
+    article_count: int | None = None
+
+
+class ArticleListItem(Schema):
+    id: UUID
+    title: str
+    slug: str | None
+    state: str
+    published_at: datetime | None
+    global_visibility: str
+    channel: ArticleChannelRef
+    hero_image_url: str | None
+
+    @staticmethod
+    def resolve_channel(obj: Any) -> dict[str, Any]:
+        channel = obj.channel
+        return {"id": channel.id, "name": channel.name}
+
+    @staticmethod
+    def resolve_hero_image_url(obj: Any) -> str | None:
+        hero = obj.hero_image
+        if hero is None:
+            return None
+        return hero.url

--- a/src/django-backend/api/schemas/article.py
+++ b/src/django-backend/api/schemas/article.py
@@ -82,32 +82,6 @@ class ArticleOut(Schema):
         return obj.is_globally_visible
 
 
-class ChannelCreate(Schema):
-    name: str
-
-
-class ChannelRename(Schema):
-    name: str
-
-
-class ChannelReassign(Schema):
-    target_channel_id: UUID
-
-
-class ChannelResponse(Schema):
-    id: UUID
-    name: str
-
-
-class ChannelReassignResponse(Schema):
-    reassigned: int
-
-
-class ChannelConflictResponse(Schema):
-    detail: str
-    article_count: int | None = None
-
-
 class ArticleListItem(Schema):
     id: UUID
     title: str

--- a/src/django-backend/api/schemas/channel.py
+++ b/src/django-backend/api/schemas/channel.py
@@ -1,0 +1,29 @@
+from uuid import UUID
+
+from ninja import Schema
+
+
+class ChannelCreate(Schema):
+    name: str
+
+
+class ChannelRename(Schema):
+    name: str
+
+
+class ChannelReassign(Schema):
+    target_channel_id: UUID
+
+
+class ChannelResponse(Schema):
+    id: UUID
+    name: str
+
+
+class ChannelReassignResponse(Schema):
+    reassigned: int
+
+
+class ChannelConflictResponse(Schema):
+    detail: str
+    article_count: int | None = None

--- a/src/django-backend/api/schemas/notification.py
+++ b/src/django-backend/api/schemas/notification.py
@@ -6,6 +6,7 @@ from pydantic import model_validator
 
 from services.notifications import (
     NotificationGroup,
+    NotificationGroupKind,
     NotificationHeadlineKind,
     NotificationSummary,
 )
@@ -33,45 +34,62 @@ class NotificationProjectResponse(Schema):
 
 
 class NotificationGroupResponse(Schema):
-    root_discussion_id: UUID
+    kind: NotificationGroupKind
     project: NotificationProjectResponse
-    headline_kind: NotificationHeadlineKind
-    actor_names: list[str]
     latest_body_excerpt: str
     latest_event_at: datetime
     unread_count: int
-    latest_comment_id: UUID
+    # Discussion-specific (null for article groups)
+    root_discussion_id: UUID | None = None
+    headline_kind: NotificationHeadlineKind | None = None
+    actor_names: list[str] = []
+    latest_comment_id: UUID | None = None
+    # Article-specific (null for discussion groups)
+    article_id: UUID | None = None
+    article_slug: str | None = None
+    article_title: str | None = None
+    channel_name: str | None = None
 
     @classmethod
     def from_dataclass(cls, group: NotificationGroup) -> "NotificationGroupResponse":
         return cls(
-            root_discussion_id=group.root_discussion_id,
+            kind=group.kind,
             project=NotificationProjectResponse(
                 id=group.project.id,
                 slug=group.project.slug,
                 title=group.project.title,
                 image_url=group.project.image_url,
             ),
-            headline_kind=group.headline_kind,
-            actor_names=group.actor_names,
             latest_body_excerpt=group.latest_body_excerpt,
             latest_event_at=group.latest_event_at,
             unread_count=group.unread_count,
+            root_discussion_id=group.root_discussion_id,
+            headline_kind=group.headline_kind,
+            actor_names=list(group.actor_names),
             latest_comment_id=group.latest_comment_id,
+            article_id=group.article_id,
+            article_slug=group.article_slug,
+            article_title=group.article_title,
+            channel_name=group.channel_name,
         )
 
 
 class MarkThreadReadRequest(Schema):
     root_discussion_id: UUID | None = None
     comment_id: UUID | None = None
+    article_id: UUID | None = None
 
     @model_validator(mode="after")
     def exactly_one(self) -> "MarkThreadReadRequest":
         provided = sum(
-            x is not None for x in (self.root_discussion_id, self.comment_id)
+            x is not None
+            for x in (self.root_discussion_id, self.comment_id, self.article_id)
         )
         if provided != 1:
-            msg = "exactly one of root_discussion_id or comment_id is required"
+            msg = (
+                "exactly one of root_discussion_id, comment_id or article_id"
+                " is required"
+            )
             raise ValueError(msg)
         return self
 

--- a/src/django-backend/services/articles/django_impl/query.py
+++ b/src/django-backend/services/articles/django_impl/query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from apps.articles.models import Article, ArticleState
+from apps.follows.models import Channel
 from services.articles.query_interface import ArticleQueryInterface
 
 if TYPE_CHECKING:
@@ -42,3 +43,6 @@ class DjangoArticleQuery(ArticleQueryInterface):
         if not include_drafts:
             qs = qs.filter(state=ArticleState.PUBLISHED)
         return qs
+
+    def list_channels_for_project(self, project_id: UUID) -> QuerySet[Channel]:
+        return Channel.objects.filter(project_id=project_id).order_by("name")

--- a/src/django-backend/services/articles/django_impl/query.py
+++ b/src/django-backend/services/articles/django_impl/query.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.db.models import F
+
 from apps.articles.models import Article, ArticleState
 from apps.follows.models import Channel
 from services.articles.query_interface import ArticleQueryInterface
@@ -37,8 +39,10 @@ class DjangoArticleQuery(ArticleQueryInterface):
         *,
         include_drafts: bool = False,
     ) -> QuerySet[Article]:
-        qs = Article.objects.filter(project_id=project_id).select_related(
-            "channel", "author", "hero_image"
+        qs = (
+            Article.objects.filter(project_id=project_id)
+            .select_related("channel", "author", "hero_image")
+            .order_by(F("published_at").desc(nulls_first=True), "-created_at")
         )
         if not include_drafts:
             qs = qs.filter(state=ArticleState.PUBLISHED)
@@ -46,3 +50,8 @@ class DjangoArticleQuery(ArticleQueryInterface):
 
     def list_channels_for_project(self, project_id: UUID) -> QuerySet[Channel]:
         return Channel.objects.filter(project_id=project_id).order_by("name")
+
+    def get_channel_in_project(
+        self, project_id: UUID, channel_id: UUID
+    ) -> Channel | None:
+        return Channel.objects.filter(project_id=project_id, pk=channel_id).first()

--- a/src/django-backend/services/articles/query_interface.py
+++ b/src/django-backend/services/articles/query_interface.py
@@ -33,3 +33,8 @@ class ArticleQueryInterface(ABC):
 
     @abstractmethod
     def list_channels_for_project(self, project_id: UUID) -> QuerySet[Channel]: ...
+
+    @abstractmethod
+    def get_channel_in_project(
+        self, project_id: UUID, channel_id: UUID
+    ) -> Channel | None: ...

--- a/src/django-backend/services/articles/query_interface.py
+++ b/src/django-backend/services/articles/query_interface.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from django.db.models import QuerySet
 
     from apps.articles.models import Article
+    from apps.follows.models import Channel
 
 
 class ArticleQueryInterface(ABC):
@@ -29,3 +30,6 @@ class ArticleQueryInterface(ABC):
         *,
         include_drafts: bool = False,
     ) -> QuerySet[Article]: ...
+
+    @abstractmethod
+    def list_channels_for_project(self, project_id: UUID) -> QuerySet[Channel]: ...

--- a/src/django-backend/services/notifications/__init__.py
+++ b/src/django-backend/services/notifications/__init__.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from uuid import UUID
@@ -7,6 +7,11 @@ from uuid import UUID
 class NotificationHeadlineKind(str, Enum):
     STARTED = "started"
     REPLIED = "replied"
+
+
+class NotificationGroupKind(str, Enum):
+    DISCUSSION = "discussion"
+    ARTICLE = "article"
 
 
 @dataclass(frozen=True)
@@ -19,14 +24,21 @@ class NotificationProject:
 
 @dataclass(frozen=True)
 class NotificationGroup:
-    root_discussion_id: UUID
+    kind: NotificationGroupKind
     project: NotificationProject
-    headline_kind: NotificationHeadlineKind
-    actor_names: list[str]
-    latest_body_excerpt: str
     latest_event_at: datetime
     unread_count: int
-    latest_comment_id: UUID
+    latest_body_excerpt: str
+    # Discussion-specific fields (None for article groups)
+    root_discussion_id: UUID | None = None
+    headline_kind: NotificationHeadlineKind | None = None
+    actor_names: list[str] = field(default_factory=list)
+    latest_comment_id: UUID | None = None
+    # Article-specific fields (None for discussion groups)
+    article_id: UUID | None = None
+    article_slug: str | None = None
+    article_title: str | None = None
+    channel_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -37,6 +49,7 @@ class NotificationSummary:
 
 __all__ = [
     "NotificationGroup",
+    "NotificationGroupKind",
     "NotificationHeadlineKind",
     "NotificationProject",
     "NotificationSummary",

--- a/src/django-backend/services/notifications/django_impl/handler.py
+++ b/src/django-backend/services/notifications/django_impl/handler.py
@@ -13,6 +13,7 @@ from apps.follows.models import FollowChannelPreference
 from apps.notifications.models import Notification, NotificationCadence
 from services.notifications import (
     NotificationGroup,
+    NotificationGroupKind,
     NotificationHeadlineKind,
     NotificationProject,
     NotificationSummary,
@@ -72,6 +73,7 @@ def _build_group(rows: Iterable[Notification], root_id: UUID) -> NotificationGro
             actor_names.append(name)
 
     return NotificationGroup(
+        kind=NotificationGroupKind.DISCUSSION,
         root_discussion_id=root_id,
         project=NotificationProject(
             id=project.id,
@@ -85,6 +87,35 @@ def _build_group(rows: Iterable[Notification], root_id: UUID) -> NotificationGro
         latest_event_at=latest.discussion.created_at,
         unread_count=len(rows),
         latest_comment_id=latest.discussion_id,
+    )
+
+
+def _build_article_group(rows: list[Notification]) -> NotificationGroup:
+    from services import REPO  # noqa: PLC0415
+
+    rows = sorted(
+        rows,
+        key=lambda n: n.article.published_at or n.created_at,
+        reverse=True,
+    )
+    latest = rows[0]
+    article = latest.article
+    project = article.project
+    return NotificationGroup(
+        kind=NotificationGroupKind.ARTICLE,
+        project=NotificationProject(
+            id=project.id,
+            slug=project.slug,
+            title=project.title,
+            image_url=REPO.project.get_project_icon_url(project),
+        ),
+        latest_event_at=article.published_at or latest.created_at,
+        unread_count=len(rows),
+        latest_body_excerpt=_body_excerpt(article.body),
+        article_id=article.id,
+        article_slug=article.slug,
+        article_title=article.title,
+        channel_name=article.channel.name,
     )
 
 
@@ -322,17 +353,28 @@ class DjangoNotificationHandler(NotificationHandlerInterface):
     ) -> list[NotificationGroup]:
         from services import REPO  # noqa: PLC0415
 
-        rows = list(
+        discussion_rows = list(
             REPO.notifications.list_unread_for_user(user_id).prefetch_related(
                 "discussion__project__images__variants"
             )
         )
 
         by_root: defaultdict[UUID, list[Notification]] = defaultdict(list)
-        for r in rows:
+        for r in discussion_rows:
             by_root[_root_id(r)].append(r)
 
         groups = [_build_group(rs, root_id) for root_id, rs in by_root.items()]
+
+        article_rows = list(
+            REPO.notifications.list_unread_articles_for_user(user_id).prefetch_related(
+                "article__project__images__variants"
+            )
+        )
+        by_article: defaultdict[UUID, list[Notification]] = defaultdict(list)
+        for r in article_rows:
+            by_article[r.article_id].append(r)
+        groups.extend(_build_article_group(rs) for rs in by_article.values())
+
         groups.sort(key=lambda g: g.latest_event_at, reverse=True)
         return groups[:limit]
 

--- a/src/django-backend/services/notifications/django_impl/handler.py
+++ b/src/django-backend/services/notifications/django_impl/handler.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from django.utils import timezone
 
-from apps.articles.models import Article
+from apps.articles.models import Article, ArticleState
 from apps.discussions.models import Discussion
 from apps.follows.models import FollowChannelPreference
 from apps.notifications.models import Notification, NotificationCadence
@@ -184,7 +184,7 @@ class DjangoNotificationHandler(NotificationHandlerInterface):
             logger.warning("Article %s not found for notification", article_id)
             return
 
-        if article.state != "published":
+        if article.state != ArticleState.PUBLISHED:
             return
 
         # Find every Follow on this project with a ChannelPreference for the

--- a/src/django-backend/services/notifications/django_impl/query.py
+++ b/src/django-backend/services/notifications/django_impl/query.py
@@ -21,10 +21,11 @@ def _unread_qs(user_id: UUID) -> QuerySet[Notification]:
 
 
 def _unread_discussion_qs(user_id: UUID) -> QuerySet[Notification]:
-    """Discussion-only slice — the in-app surfaces that branch on `kind`
-    will be extended in a later chunk; for now article rows are excluded
-    here so the existing groups/summary path keeps working unchanged."""
     return _unread_qs(user_id).filter(discussion__isnull=False)
+
+
+def _unread_article_qs(user_id: UUID) -> QuerySet[Notification]:
+    return _unread_qs(user_id).filter(article__isnull=False)
 
 
 class DjangoNotificationQuery(NotificationQueryInterface):
@@ -41,14 +42,27 @@ class DjangoNotificationQuery(NotificationQueryInterface):
             .order_by("-discussion__created_at")
         )
 
-    def count_unread_groups_for_user(self, user_id: UUID) -> int:
+    def list_unread_articles_for_user(self, user_id: UUID) -> QuerySet[Notification]:
         return (
+            _unread_article_qs(user_id)
+            .select_related(
+                "article",
+                "article__project",
+                "article__channel",
+            )
+            .order_by("-article__published_at", "-created_at")
+        )
+
+    def count_unread_groups_for_user(self, user_id: UUID) -> int:
+        discussions = (
             _unread_discussion_qs(user_id)
             .annotate(root=Coalesce(F("discussion__parent_id"), F("discussion_id")))
             .values("root")
             .distinct()
             .count()
         )
+        articles = _unread_article_qs(user_id).values("article_id").distinct().count()
+        return discussions + articles
 
     def unread_rows_for_thread(
         self, user_id: UUID, root_discussion_id: UUID

--- a/src/django-backend/services/notifications/django_impl/test_query.py
+++ b/src/django-backend/services/notifications/django_impl/test_query.py
@@ -80,7 +80,7 @@ class TestCountUnreadGroupsForUser:
 
         assert_that(query.count_unread_groups_for_user(user.id), equal_to(0))
 
-    def test_count_query_runs_in_one_query_with_distinct(self, query) -> None:
+    def test_count_query_runs_with_distinct(self, query) -> None:
         user = UserFactory()
         project = ProjectFactory()
         root = DiscussionFactory(project=project)
@@ -93,9 +93,11 @@ class TestCountUnreadGroupsForUser:
             result = query.count_unread_groups_for_user(user.id)
 
         assert_that(result, equal_to(1))
-        assert_that(len(ctx.captured_queries), equal_to(1))
-        sql = ctx.captured_queries[0]["sql"].lower()
-        assert "distinct" in sql or "group by" in sql, sql
+        # One query per kind (discussion + article) — bounded N, not N+1.
+        assert_that(len(ctx.captured_queries), equal_to(2))
+        for q in ctx.captured_queries:
+            sql = q["sql"].lower()
+            assert "distinct" in sql or "group by" in sql, sql
 
 
 @pytest.mark.django_db

--- a/src/django-backend/services/notifications/query_interface.py
+++ b/src/django-backend/services/notifications/query_interface.py
@@ -16,6 +16,11 @@ class NotificationQueryInterface(ABC):
     def list_unread_for_user(self, user_id: UUID) -> QuerySet[Notification]: ...
 
     @abstractmethod
+    def list_unread_articles_for_user(
+        self, user_id: UUID
+    ) -> QuerySet[Notification]: ...
+
+    @abstractmethod
     def count_unread_groups_for_user(self, user_id: UUID) -> int: ...
 
     @abstractmethod

--- a/src/web-ui/backend-openapi.json
+++ b/src/web-ui/backend-openapi.json
@@ -1423,6 +1423,928 @@
         ]
       }
     },
+    "/api/projects/{slug}/articles": {
+      "post": {
+        "operationId": "api_routers_articles_create_article",
+        "summary": "Create Article",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Articles"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArticleCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      },
+      "get": {
+        "operationId": "api_routers_articles_list_articles",
+        "summary": "List Articles",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ArticleListItem"
+                  },
+                  "title": "Response",
+                  "type": "array"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Articles"
+        ]
+      }
+    },
+    "/api/projects/{slug}/articles/by-slug/{article_slug}": {
+      "get": {
+        "operationId": "api_routers_articles_get_article_by_slug",
+        "summary": "Get Article By Slug",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "article_slug",
+            "schema": {
+              "title": "Article Slug",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleOut"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Articles"
+        ]
+      }
+    },
+    "/api/projects/{slug}/articles/{article_id}": {
+      "get": {
+        "operationId": "api_routers_articles_get_article",
+        "summary": "Get Article",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "article_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Articles"
+        ],
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "api_routers_articles_patch_article",
+        "summary": "Patch Article",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "article_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Articles"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArticleUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "api_routers_articles_delete_article",
+        "summary": "Delete Article",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "article_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Articles"
+        ],
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      }
+    },
+    "/api/projects/{slug}/articles/{article_id}/publish": {
+      "post": {
+        "operationId": "api_routers_articles_publish_article",
+        "summary": "Publish Article",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "article_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleOut"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Articles"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArticlePublish"
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      }
+    },
+    "/api/projects/{slug}/channels": {
+      "get": {
+        "operationId": "api_routers_channels_list_channels",
+        "summary": "List Channels",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ChannelResponse"
+                  },
+                  "title": "Response",
+                  "type": "array"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Channels"
+        ]
+      },
+      "post": {
+        "operationId": "api_routers_channels_create_channel",
+        "summary": "Create Channel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Channels"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChannelCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      }
+    },
+    "/api/projects/{slug}/channels/{channel_id}": {
+      "patch": {
+        "operationId": "api_routers_channels_rename_channel",
+        "summary": "Rename Channel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "channel_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Channel Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Channels"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChannelRename"
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "api_routers_channels_delete_channel",
+        "summary": "Delete Channel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "channel_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Channel Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelConflictResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Channels"
+        ],
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      }
+    },
+    "/api/projects/{slug}/channels/{channel_id}/reassign": {
+      "post": {
+        "operationId": "api_routers_channels_reassign_channel",
+        "summary": "Reassign Channel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "channel_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Channel Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelReassignResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Channels"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChannelReassign"
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ]
+      }
+    },
     "/api/follows": {
       "get": {
         "operationId": "api_routers_follows_list_follows",
@@ -4632,6 +5554,477 @@
         "title": "FollowChannelPreferencePatch",
         "type": "object"
       },
+      "ArticleChannelRef": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "ArticleChannelRef",
+        "type": "object"
+      },
+      "ArticleOut": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ArticleProjectRef"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ArticleChannelRef"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicUserProfile"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "body": {
+            "title": "Body",
+            "type": "string"
+          },
+          "hero_image_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image Id"
+          },
+          "hero_image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image Url"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "external_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "External Url"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          },
+          "global_visibility": {
+            "title": "Global Visibility",
+            "type": "string"
+          },
+          "is_globally_visible": {
+            "title": "Is Globally Visible",
+            "type": "boolean"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "project",
+          "channel",
+          "author",
+          "title",
+          "body",
+          "hero_image_id",
+          "hero_image_url",
+          "slug",
+          "source",
+          "external_url",
+          "state",
+          "published_at",
+          "global_visibility",
+          "is_globally_visible",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ArticleOut",
+        "type": "object"
+      },
+      "ArticleProjectRef": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "slug",
+          "title"
+        ],
+        "title": "ArticleProjectRef",
+        "type": "object"
+      },
+      "ArticleCreate": {
+        "properties": {
+          "channel_id": {
+            "format": "uuid",
+            "title": "Channel Id",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "title": "Title",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "title": "Body",
+            "type": "string"
+          },
+          "hero_image_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image Id"
+          }
+        },
+        "required": [
+          "channel_id"
+        ],
+        "title": "ArticleCreate",
+        "type": "object"
+      },
+      "ArticleListItem": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          },
+          "global_visibility": {
+            "title": "Global Visibility",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ArticleChannelRef"
+          },
+          "hero_image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image Url"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "state",
+          "published_at",
+          "global_visibility",
+          "channel",
+          "hero_image_url"
+        ],
+        "title": "ArticleListItem",
+        "type": "object"
+      },
+      "ArticleUpdate": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "hero_image_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image Id"
+          },
+          "channel_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channel Id"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          }
+        },
+        "title": "ArticleUpdate",
+        "type": "object"
+      },
+      "ArticlePublish": {
+        "properties": {
+          "published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          }
+        },
+        "title": "ArticlePublish",
+        "type": "object"
+      },
+      "ChannelResponse": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "ChannelResponse",
+        "type": "object"
+      },
+      "ChannelCreate": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ChannelCreate",
+        "type": "object"
+      },
+      "ChannelRename": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ChannelRename",
+        "type": "object"
+      },
+      "ChannelConflictResponse": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "article_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Article Count"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ChannelConflictResponse",
+        "type": "object"
+      },
+      "ChannelReassignResponse": {
+        "properties": {
+          "reassigned": {
+            "title": "Reassigned",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "reassigned"
+        ],
+        "title": "ChannelReassignResponse",
+        "type": "object"
+      },
+      "ChannelReassign": {
+        "properties": {
+          "target_channel_id": {
+            "format": "uuid",
+            "title": "Target Channel Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_channel_id"
+        ],
+        "title": "ChannelReassign",
+        "type": "object"
+      },
       "ProjectCreate": {
         "properties": {
           "website_url": {
@@ -5925,25 +7318,21 @@
         "title": "NotificationSummaryResponse",
         "type": "object"
       },
+      "NotificationGroupKind": {
+        "enum": [
+          "discussion",
+          "article"
+        ],
+        "title": "NotificationGroupKind",
+        "type": "string"
+      },
       "NotificationGroupResponse": {
         "properties": {
-          "root_discussion_id": {
-            "format": "uuid",
-            "title": "Root Discussion Id",
-            "type": "string"
+          "kind": {
+            "$ref": "#/components/schemas/NotificationGroupKind"
           },
           "project": {
             "$ref": "#/components/schemas/NotificationProjectResponse"
-          },
-          "headline_kind": {
-            "$ref": "#/components/schemas/NotificationHeadlineKind"
-          },
-          "actor_names": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Actor Names",
-            "type": "array"
           },
           "latest_body_excerpt": {
             "title": "Latest Body Excerpt",
@@ -5958,21 +7347,100 @@
             "title": "Unread Count",
             "type": "integer"
           },
+          "root_discussion_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Root Discussion Id"
+          },
+          "headline_kind": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NotificationHeadlineKind"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "actor_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Actor Names",
+            "type": "array"
+          },
           "latest_comment_id": {
-            "format": "uuid",
-            "title": "Latest Comment Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Comment Id"
+          },
+          "article_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Article Id"
+          },
+          "article_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Article Slug"
+          },
+          "article_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Article Title"
+          },
+          "channel_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channel Name"
           }
         },
         "required": [
-          "root_discussion_id",
+          "kind",
           "project",
-          "headline_kind",
-          "actor_names",
           "latest_body_excerpt",
           "latest_event_at",
-          "unread_count",
-          "latest_comment_id"
+          "unread_count"
         ],
         "title": "NotificationGroupResponse",
         "type": "object"
@@ -6066,6 +7534,18 @@
               }
             ],
             "title": "Comment Id"
+          },
+          "article_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Article Id"
           }
         },
         "title": "MarkThreadReadRequest",

--- a/src/web-ui/src/app/notifications/NotificationsFeed.tsx
+++ b/src/web-ui/src/app/notifications/NotificationsFeed.tsx
@@ -11,6 +11,12 @@ export function NotificationsFeed() {
   const { isReady } = useRequireAuth();
   const { groups, refreshGroups, markThreadRead, markAllRead } =
     useNotifications();
+  const discussionGroups = groups.filter(
+    (
+      g
+    ): g is typeof g & { root_discussion_id: string } =>
+      g.kind === "discussion" && typeof g.root_discussion_id === "string"
+  );
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState(false);
 
@@ -45,7 +51,7 @@ export function NotificationsFeed() {
   };
 
   const handleMarkAll = async () => {
-    if (groups.length === 0) return;
+    if (discussionGroups.length === 0) return;
     setBusy(true);
     try {
       await markAllRead();
@@ -56,7 +62,7 @@ export function NotificationsFeed() {
     }
   };
 
-  if (groups.length === 0) {
+  if (discussionGroups.length === 0) {
     return (
       <div className="bg-white rounded-xl border border-border px-6 py-16 text-center">
         <h2 className="text-lg font-medium text-foreground">
@@ -83,14 +89,14 @@ export function NotificationsFeed() {
         <button
           type="button"
           onClick={handleMarkAll}
-          disabled={busy || groups.length === 0}
+          disabled={busy || discussionGroups.length === 0}
           className="px-3 py-1.5 text-xs font-medium border border-border rounded-md text-foreground hover:bg-slate-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Mark all as read
         </button>
       </div>
       <div className="bg-white rounded-xl border border-border divide-y divide-slate-100 overflow-hidden">
-        {groups.map((group) => {
+        {discussionGroups.map((group) => {
           const isSelected = selected.has(group.root_discussion_id);
           return (
             <div

--- a/src/web-ui/src/contexts/notifications.tsx
+++ b/src/web-ui/src/contexts/notifications.tsx
@@ -37,12 +37,22 @@ const NotificationsContext = createContext<NotificationsContextValue | undefined
   undefined
 );
 
+function discussionGroupsOnly(
+  groups: NotificationGroup[]
+): (NotificationGroup & { root_discussion_id: string })[] {
+  return groups.filter(
+    (g): g is NotificationGroup & { root_discussion_id: string } =>
+      g.kind === "discussion" &&
+      typeof g.root_discussion_id === "string"
+  );
+}
+
 function diffActiveRoots(
   prev: Set<string>,
   next: NotificationGroup[]
 ): string[] {
   const newly: string[] = [];
-  for (const g of next) {
+  for (const g of discussionGroupsOnly(next)) {
     if (!prev.has(g.root_discussion_id)) {
       newly.push(g.root_discussion_id);
     }
@@ -65,14 +75,16 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       nextGroups
     );
     const groupsByRoot = new Map<string, NotificationGroup>();
-    for (const g of nextGroups) groupsByRoot.set(g.root_discussion_id, g);
+    for (const g of discussionGroupsOnly(nextGroups)) {
+      groupsByRoot.set(g.root_discussion_id, g);
+    }
     if (newlyActiveRoots.length > 0) {
       for (const listener of listenersRef.current) {
         listener({ newlyActiveRoots, groupsByRoot });
       }
     }
     lastGroupRootsRef.current = new Set(
-      nextGroups.map((g) => g.root_discussion_id)
+      discussionGroupsOnly(nextGroups).map((g) => g.root_discussion_id)
     );
   }, []);
 


### PR DESCRIPTION
Stacked on top of PR #67 (chunks 1 + 2). Base is `add-article-authoring`, so the diff here is just what chunk 3 adds.

## Scope — sections 6.3–6.4, 7, 10.1–10.2, 10.5 of `openspec/changes/add-article-authoring/tasks.md`

All the thin pass-through API surface for the article + channel + notification work that the services layer (chunk 2) already supports, plus tests.

### Article routes — `api/routers/articles.py`
- `POST /api/projects/{slug}/articles` — create draft (full_edit)
- `GET  /api/projects/{slug}/articles` — list (drafts visible to full_edit, published-only otherwise)
- `GET  /api/projects/{slug}/articles/{id}` — read article in editor (draft 403 for non-author/non-full_edit)
- `PATCH /api/projects/{slug}/articles/{id}` — update (full_edit)
- `POST /api/projects/{slug}/articles/{id}/publish` — publish (full_edit; 422 if title/body/hero missing)
- `DELETE /api/projects/{slug}/articles/{id}` — hard delete (full_edit)
- `GET  /api/projects/{slug}/articles/by-slug/{article_slug}` — public render path; 404 for drafts unless author / full_edit

### Channel routes — `api/routers/channels.py`
- `GET  /api/projects/{slug}/channels` — list (public; chunk-7 dropdown source)
- `POST /api/projects/{slug}/channels` — add (409 on duplicate name)
- `PATCH /api/projects/{slug}/channels/{id}` — rename (409 on duplicate)
- `DELETE /api/projects/{slug}/channels/{id}` — delete (409 has-articles with `article_count` in body; 409 only-channel)
- `POST /api/projects/{slug}/channels/{id}/reassign` — bulk reassign articles to another channel on the same project

Permission check is `REPO.project.user_can_edit(project.id, user.id)` (i.e. `ProjectContributor` with `full_edit=True`) on every write path. No `Article.objects`, `Channel.objects`, or `FollowChannelPreference.objects` references in either router — enforced by a grep-based test in each test file.

### Notifications surface
- `POST /api/notifications/mark-thread-read` now accepts `article_id` as a third XOR alternative; 422 if zero or 2+ of `{root_discussion_id, comment_id, article_id}` are supplied.
- `GET /api/notifications/groups` response gains a `kind` discriminator (`\"discussion\"` / `\"article\"`). Article groups carry `article_id` / `article_slug` / `article_title` / `channel_name`. `NotificationGroup` dataclass widened with optional article fields; `REPO.notifications` gains `list_unread_articles_for_user`; `count_unread_groups_for_user` now sums distinct discussion roots + distinct article ids (so the bell-dot summary reflects both kinds).
- Existing frontend consumers (`contexts/notifications.tsx`, `NotificationsFeed.tsx`) narrowed to `kind === \"discussion\"` so the existing surfaces keep compiling; article-kind FE rendering stays deferred to chunks 14+.

### Schemas + types
- `api/schemas/article.py` — `ArticleCreate`, `ArticleUpdate`, `ArticlePublish`, `ArticleOut`, `ArticleListItem`, and the channel request/response schemas (`ChannelCreate`, `ChannelRename`, `ChannelReassign`, `ChannelResponse`, `ChannelConflictResponse`, `ChannelReassignResponse`).
- `backend-openapi.json` regenerated via `make extract-openapi`. (`api-types.ts` is gitignored — devs regenerate locally.)

### Tests — 62 new
- `api/routers/test_articles.py` — 33 tests across 7 classes: 401 / 403 / 404 / 422 + happy paths for every endpoint, plus a router-has-no-ORM-access invariant test.
- `api/routers/test_channels.py` — 22 tests across 6 classes: 401 / 403 / 404 / 409 / 422 + happy paths, including the `article_count` body shape on the delete-with-articles 409, and the only-channel 409 guard. Same ORM-access invariant test.
- `api/routers/test_notifications.py` extended with `TestGroupsEndpointArticleKind` (3 tests) and `TestMarkThreadReadByArticle` (4 tests); existing `test_returns_groups` updated to assert `kind=\"discussion\"`.
- `services/notifications/django_impl/test_query.py::test_count_query_runs_with_distinct` updated to expect two queries (one per kind) reflecting the wider summary path.

## Notes for review

- Two minor scope additions vs the strict tasks.md text, both pulled in for review here rather than being held over:
  - `GET /api/projects/{slug}/channels` (chunk 7 needs it for the dropdown).
  - `GET /api/projects/{slug}/articles` (list endpoint).
- The four-arg routes do an existence/cross-project check via `REPO.articles.get_by_id` before the mutating call so cross-project URL tampering returns 404 cleanly. This counts as a permission/scope check, not the route's \"one service-layer call\" — happy to discuss if you'd prefer that check moved into the handler instead.
- Chunk 4 (send-path flip + `email_opt_in_*` drop) is the next breaking-change chunk and will land as its own PR.

## Test plan
- [x] `uv run pytest` — 844 passing (was 782 going into this chunk; +62 new)
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `make extract-openapi` + `npm run generate-types` regenerate cleanly; `npm run lint` clean in `src/web-ui/`
- [x] `openspec validate add-article-authoring`
- [ ] Manual smoke through the new article + channel routes once chunk 7+ FE lands (the surfaces aren't reachable from the UI yet)