### PR TITLE
Fix 500 on project admin search

### DIFF
--- a/src/django-backend/apps/projects/admin.py
+++ b/src/django-backend/apps/projects/admin.py
@@ -160,7 +160,13 @@ class ProjectAdmin(admin.ModelAdmin):
         "created_at",
         "tags",
     )
-    search_fields = ("title", "description", "creator__email", "creator__username")
+    search_fields = (
+        "title",
+        "description",
+        "creator__email",
+        "creator__first_name",
+        "creator__last_name",
+    )
     ordering = ("-created_at",)
     readonly_fields = (
         "id",

--- a/src/django-backend/tests/test_admin_search.py
+++ b/src/django-backend/tests/test_admin_search.py
@@ -1,0 +1,44 @@
+"""Django validates `search_fields` only when a search actually runs, so a typo
+there is a latent 500. Exercise every registered admin's search once."""
+
+import pytest
+from django.apps import apps
+from django.contrib import admin
+from django.contrib.admin.options import ModelAdmin
+from django.contrib.admin.sites import NotRegistered
+from django.test import RequestFactory
+
+from tests.factories import UserFactory
+
+
+def searchable_admins() -> list[ModelAdmin]:
+    admins = []
+    for model in apps.get_models():
+        try:
+            model_admin = admin.site.get_model_admin(model)
+        except NotRegistered:
+            continue
+        if model_admin.get_search_fields(None):
+            admins.append(model_admin)
+    return admins
+
+
+def admin_id(model_admin: ModelAdmin) -> str:
+    return model_admin.model.__name__
+
+
+def run_admin_search(model_admin: ModelAdmin, term: str) -> None:
+    request = RequestFactory().get("/admin/", {"q": term})
+    request.user = UserFactory(is_staff=True, is_superuser=True)
+
+    queryset, _ = model_admin.get_search_results(
+        request, model_admin.get_queryset(request), term
+    )
+
+    list(queryset[:1])
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("model_admin", searchable_admins(), ids=admin_id)
+def test_admin_search_fields_are_queryable(model_admin: ModelAdmin):
+    run_admin_search(model_admin, "foo")


### PR DESCRIPTION
## Problem

Searching in `/admin/projects/project/` returned a 500:

```
django.core.exceptions.FieldError: Unsupported lookup 'username__icontains'
for ForeignKey or join on the field not permitted.
```

`ProjectAdmin.search_fields` listed `creator__username`, but our `User` is a
custom `AbstractBaseUser` with `USERNAME_FIELD = "email"` and no `username`
column, so the ORM read `username__icontains` as a lookup on the `creator` FK.
Django's admin system checks don't validate `search_fields`, so this only
surfaced when someone actually searched.

## Changes

- Replace `creator__username` with `creator__first_name` / `creator__last_name`,
  so searching by a creator's name still works — same pattern as
  `CompetitionReviewerAdmin`.
- Add `tests/test_admin_search.py`: parametrises over every registered
  `ModelAdmin` declaring `search_fields` and runs a real search against each.
  It reproduced the production `FieldError` on `projects.Project` before the
  fix; the other 18 admins were already fine.