### PR TITLE
Article link previews: use the article image on Twitter/Discord cards

### DIFF
--- a/src/web-ui/src/app/competitions/[id]/competition-social-metadata.test.ts
+++ b/src/web-ui/src/app/competitions/[id]/competition-social-metadata.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Competition } from "@/lib/api";
+
+vi.mock("@/lib/api/server", () => ({
+  fetchCompetition: vi.fn(),
+  ApiNotFoundError: class ApiNotFoundError extends Error {},
+}));
+
+import { fetchCompetition } from "@/lib/api/server";
+import { generateMetadata } from "./page";
+
+function aCompetition(overrides: Partial<Competition> = {}): Competition {
+  return {
+    name: "Spínat",
+    start_date: "2026-01-01T00:00:00Z",
+    submission_deadline: "2026-02-01T00:00:00Z",
+    image_url: "https://cdn.naglasupan.is/competitions/spinat.jpg",
+    ...overrides,
+  } as unknown as Competition;
+}
+
+async function metadataFor(competition: Competition) {
+  vi.mocked(fetchCompetition).mockResolvedValue(competition);
+  return generateMetadata({ params: Promise.resolve({ id: "spinat" }) });
+}
+
+describe("competition social card metadata", () => {
+  it("puts the competition image on the twitter card", async () => {
+    const metadata = await metadataFor(aCompetition());
+
+    expect(metadata.twitter).toMatchObject({
+      card: "summary_large_image",
+      title: "Spínat",
+      images: ["https://cdn.naglasupan.is/competitions/spinat.jpg"],
+    });
+  });
+
+  it("falls back to the site logo when the competition has no image", async () => {
+    const metadata = await metadataFor(aCompetition({ image_url: null }));
+
+    expect(metadata.twitter).toMatchObject({
+      card: "summary",
+      images: ["/icons/app/logo.png"],
+    });
+  });
+});

--- a/src/web-ui/src/app/competitions/[id]/page.tsx
+++ b/src/web-ui/src/app/competitions/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { CompetitionReveal } from "./CompetitionReveal";
 import { fetchCompetition, ApiNotFoundError } from "@/lib/api/server";
+import { socialCard } from "@/lib/social-card";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -23,16 +24,15 @@ export async function generateMetadata({
       day: "numeric",
       year: "numeric",
     });
+    const description = `${competition.name} — ${start} to ${end}`;
     return {
       title: competition.name,
-      description: `${competition.name} — ${start} to ${end}`,
-      openGraph: {
+      description,
+      ...socialCard({
         title: competition.name,
-        description: `${competition.name} — ${start} to ${end}`,
-        ...(competition.image_url && {
-          images: [{ url: competition.image_url }],
-        }),
-      },
+        description,
+        imageUrl: competition.image_url,
+      }),
     };
   } catch {
     return {};

--- a/src/web-ui/src/app/projects/[slug]/articles/[articleSlug]/article-social-metadata.test.ts
+++ b/src/web-ui/src/app/projects/[slug]/articles/[articleSlug]/article-social-metadata.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Article } from "@/lib/api";
+
+vi.mock("@/lib/api/server", () => ({
+  fetchArticleBySlug: vi.fn(),
+  getProjectOr404: vi.fn(),
+  ApiNotFoundError: class ApiNotFoundError extends Error {},
+}));
+
+import { fetchArticleBySlug } from "@/lib/api/server";
+import { generateMetadata } from "./page";
+
+function anArticle(overrides: Partial<Article> = {}): Article {
+  return {
+    title: "Voting Changes - Schulze",
+    summary: "Why the ranking page was rebuilt around the Schulze method.",
+    summary_display: "The ranking page suffered from a couple of biases.",
+    listing_image_url: "https://cdn.naglasupan.is/projects/abc/ballot-box.jpg",
+    project: { title: "naglasúpan", slug: "naglasupan" },
+    ...overrides,
+  } as unknown as Article;
+}
+
+async function metadataFor(article: Article) {
+  vi.mocked(fetchArticleBySlug).mockResolvedValue(article);
+  return generateMetadata({
+    params: Promise.resolve({
+      slug: "naglasupan",
+      articleSlug: "voting-changes-schulze",
+    }),
+  });
+}
+
+describe("article social card metadata", () => {
+  it("puts the article's listing image on the twitter card", async () => {
+    const metadata = await metadataFor(anArticle());
+
+    expect(metadata.twitter).toMatchObject({
+      images: ["https://cdn.naglasupan.is/projects/abc/ballot-box.jpg"],
+    });
+  });
+
+  it("asks for a large twitter card so scrapers do not render a thumbnail", async () => {
+    const metadata = await metadataFor(anArticle());
+
+    expect(metadata.twitter).toMatchObject({ card: "summary_large_image" });
+  });
+
+  it("titles the twitter card with the article, not the site name", async () => {
+    const metadata = await metadataFor(anArticle());
+
+    expect(metadata.twitter).toMatchObject({
+      title: "Voting Changes - Schulze",
+      description: "Why the ranking page was rebuilt around the Schulze method.",
+    });
+  });
+
+  it("falls back to the site logo when the article has no listing image", async () => {
+    const metadata = await metadataFor(anArticle({ listing_image_url: null }));
+
+    expect(metadata.twitter).toMatchObject({
+      card: "summary",
+      images: ["/icons/app/logo.png"],
+    });
+    expect(metadata.openGraph).toMatchObject({
+      images: [{ url: "/icons/app/logo.png" }],
+    });
+  });
+
+  it("keeps the article image on the open graph card", async () => {
+    const metadata = await metadataFor(anArticle());
+
+    expect(metadata.openGraph).toMatchObject({
+      type: "article",
+      images: [
+        {
+          url: "https://cdn.naglasupan.is/projects/abc/ballot-box.jpg",
+          alt: "Voting Changes - Schulze",
+        },
+      ],
+    });
+  });
+});

--- a/src/web-ui/src/app/projects/[slug]/articles/[articleSlug]/page.tsx
+++ b/src/web-ui/src/app/projects/[slug]/articles/[articleSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { ArticleRenderContent } from "./ArticleRenderContent";
+import { socialCard } from "@/lib/social-card";
 import {
   fetchArticleBySlug,
   getProjectOr404,
@@ -35,17 +36,15 @@ export async function generateMetadata({
     return {
       title: `${article.title} — ${article.project.title}`,
       description,
-      openGraph: {
+      // The uncropped original. The author's 16:9 framing is applied in CSS at
+      // render time (see CroppedImage), so there is no cropped file to point a
+      // scraper at — Facebook and Slack show the whole image.
+      ...socialCard({
         type: "article",
         title: article.title,
         description,
-        // The uncropped original. The author's 16:9 framing is applied in CSS
-        // at render time (see CroppedImage), so there is no cropped file to
-        // point a scraper at — Facebook and Slack show the whole image.
-        ...(article.listing_image_url && {
-          images: [{ url: article.listing_image_url, alt: article.title }],
-        }),
-      },
+        imageUrl: article.listing_image_url,
+      }),
     };
   } catch {
     return {};

--- a/src/web-ui/src/app/projects/[slug]/page.tsx
+++ b/src/web-ui/src/app/projects/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import { ProjectDetailContent } from "./ProjectDetailContent";
+import { socialCard } from "@/lib/social-card";
 import {
   fetchProject,
   fetchProjectArticles,
@@ -27,30 +28,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       : undefined;
     return {
       title,
-      description: description,
-      openGraph: {
-        type: "website",
-        siteName: "naglasúpan",
+      description,
+      ...socialCard({
+        title,
+        description,
         url: `https://naglasupan.is/projects/${canonicalSlug}`,
-        title,
-        description: description,
-        ...(mainImage && {
-          images: [
-            {
-              url: mainImage.url,
-              ...(mainImage.width && { width: mainImage.width }),
-              ...(mainImage.height && { height: mainImage.height }),
-              alt: project.title,
-            },
-          ],
-        }),
-      },
-      twitter: {
-        card: "summary_large_image",
-        title,
-        description: description,
-        ...(mainImage && { images: [mainImage.url] }),
-      },
+        imageUrl: mainImage?.url,
+        imageWidth: mainImage?.width ?? undefined,
+        imageHeight: mainImage?.height ?? undefined,
+      }),
     };
   } catch {
     return {};

--- a/src/web-ui/src/app/projects/[slug]/project-social-metadata.test.ts
+++ b/src/web-ui/src/app/projects/[slug]/project-social-metadata.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Project } from "@/lib/api";
+
+vi.mock("@/lib/api/server", () => ({
+  fetchProject: vi.fn(),
+  fetchProjectArticles: vi.fn(),
+  getProjectOr404: vi.fn(),
+}));
+
+import { fetchProject } from "@/lib/api/server";
+import { generateMetadata } from "./page";
+
+function aProject(overrides: Partial<Project> = {}): Project {
+  return {
+    slug: "naglasupan",
+    title: "Naglasúpan",
+    tagline: "Byggjum saman",
+    description: "A place to build things in public.",
+    images: [
+      {
+        url: "https://cdn.naglasupan.is/projects/abc/main.jpg",
+        is_main: true,
+        width: 1200,
+        height: 630,
+      },
+    ],
+    ...overrides,
+  } as unknown as Project;
+}
+
+async function metadataFor(project: Project) {
+  vi.mocked(fetchProject).mockResolvedValue(project);
+  return generateMetadata({ params: Promise.resolve({ slug: "naglasupan" }) });
+}
+
+describe("project social card metadata", () => {
+  it("puts the project's main image on both cards", async () => {
+    const metadata = await metadataFor(aProject());
+
+    expect(metadata.twitter).toMatchObject({
+      card: "summary_large_image",
+      images: ["https://cdn.naglasupan.is/projects/abc/main.jpg"],
+    });
+    expect(metadata.openGraph).toMatchObject({
+      url: "https://naglasupan.is/projects/naglasupan",
+      images: [
+        {
+          url: "https://cdn.naglasupan.is/projects/abc/main.jpg",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    });
+  });
+
+  it("falls back to the site logo when the project has no images", async () => {
+    const metadata = await metadataFor(aProject({ images: [] }));
+
+    expect(metadata.twitter).toMatchObject({
+      card: "summary",
+      images: ["/icons/app/logo.png"],
+    });
+    expect(metadata.openGraph).toMatchObject({
+      images: [{ url: "/icons/app/logo.png" }],
+    });
+  });
+});

--- a/src/web-ui/src/lib/social-card.ts
+++ b/src/web-ui/src/lib/social-card.ts
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+
+// The fallback card image: a page with no image of its own is still branded
+// rather than blank. Relative, so `metadataBase` in the root layout makes it
+// absolute.
+export const SITE_LOGO_PATH = "/icons/app/logo.png";
+export const SITE_NAME = "naglasúpan";
+
+interface SocialCardInput {
+  title: string;
+  description?: string;
+  // Absolute page URL. Omitted where the canonical URL is not worth deriving.
+  url?: string;
+  type?: "website" | "article";
+  // The page's own image, if it has one; `null`/`undefined` falls back to the
+  // site logo.
+  imageUrl?: string | null;
+  imageWidth?: number;
+  imageHeight?: number;
+}
+
+// Both halves of a link preview, always together.
+//
+// Next merges page metadata into the root layout's shallowly: a page that sets
+// `openGraph` but not `twitter` keeps the root's `twitter` tags verbatim, so
+// its card advertises the site logo under the site's title. Discord, Slack and
+// X all prefer the twitter tags when both are present, which is how an article
+// with a perfectly good `og:image` still unfurled as the naglasúpan logo
+// (issue #86). Spreading this into a page's metadata sets both, or neither.
+export function socialCard({
+  title,
+  description,
+  url,
+  type = "website",
+  imageUrl,
+  imageWidth,
+  imageHeight,
+}: SocialCardInput): Pick<Metadata, "openGraph" | "twitter"> {
+  const image = imageUrl || SITE_LOGO_PATH;
+  return {
+    openGraph: {
+      type,
+      siteName: SITE_NAME,
+      ...(url && { url }),
+      title,
+      description,
+      images: [
+        {
+          url: image,
+          ...(imageUrl && imageWidth && { width: imageWidth }),
+          ...(imageUrl && imageHeight && { height: imageHeight }),
+          alt: imageUrl ? title : SITE_NAME,
+        },
+      ],
+    },
+    twitter: {
+      // The logo is a square mark: blown up to a large card it is mostly
+      // whitespace, so only a real page image earns the big treatment.
+      card: imageUrl ? "summary_large_image" : "summary",
+      title,
+      description,
+      images: [image],
+    },
+  };
+}


### PR DESCRIPTION
Fixes #86.

Next merges page metadata into the root layout's shallowly. The article page set `openGraph` but no `twitter`, so the root layout's twitter tags survived verbatim — `card=summary`, `title=naglasúpan`, `image=logo.png`. Discord, Slack and X prefer the twitter tags when both are present, so an article with a perfectly good `og:image` still unfurled as a logo thumbnail.

Both halves now come from one helper, `socialCard()`, so a page cannot set one and forget the other. Applied to the article, competition and project pages. Pages with no image of their own fall back to the logo instead of a blank card.

Verified against the article in the issue, running a local build of this branch against the production API:

```
BEFORE (production)              AFTER (this branch)
twitter:card  = summary          twitter:card  = summary_large_image
twitter:title = naglasúpan       twitter:title = Voting Changes - Schulze
twitter:image = .../logo.png     twitter:image = .../ballot-box...jpg
```

`og:*` was already correct in both; only the twitter half changed.

9 new tests across the three pages. `make lint`, `make test`, `make build-app` and `make extra-tests` all pass.
