### PR TITLE
Warn before leaving the article editor with unsaved changes

### DIFF
--- a/openspec/changes/guard-unsaved-article-edits/.openspec.yaml
+++ b/openspec/changes/guard-unsaved-article-edits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/guard-unsaved-article-edits/design.md
+++ b/openspec/changes/guard-unsaved-article-edits/design.md
@@ -1,0 +1,204 @@
+# Design: guard unsaved article edits
+
+## Context
+
+See [`proposal.md`](proposal.md) for the motivation. The mechanics that shape
+every decision below:
+
+- The body is uncontrolled. MDXEditor owns it; the page reads it out of a ref at
+  save time (`articleDraftState.ts:20-25`). There is no state update to hang a
+  router block on, and no server copy until the author presses Save.
+- `hasUnsavedChanges` (`articleDraftState.ts:42`) already answers "would leaving
+  now lose something", comparing body and every editable field against the last
+  article the server returned. `useArticleForm` wraps it as `isDirty`
+  (`useArticleForm.ts:62`), and `useArticleDraft` hands that to `useLeaveGuard`
+  (`useArticleDraft.ts:129`). The predicate is settled; only the set of exits it
+  is consulted on is wrong.
+- The App Router has no navigation-blocking API. The Pages Router had
+  `router.events` and `routeChangeStart` with a throwable abort; `next/navigation`
+  exposes nothing equivalent, and `<Link>` navigation is a plain click handled in
+  React. There is no supported seam between "the author clicked" and "the route
+  changed" other than the click itself.
+- The links that matter are not the page's. `layout.tsx:73-78` renders
+  `Navigation` and `Footer` as siblings of `{children}`, so they mount above the
+  page in the tree and know nothing about it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Leaving the authoring page with unsaved work prompts, whichever link in the
+  document was clicked.
+- Zero changes outside `src/app/projects/[slug]/articles/`. The chrome stays
+  ignorant of the editor.
+- Nothing prompts when there is nothing to lose, and nothing prompts on the
+  exits the author took on purpose.
+
+**Non-Goals:**
+
+- Covering Back and Forward, logout, or navigation another component performs
+  in code. All three are recorded as known limitations in the proposal rather
+  than promised here.
+- Replacing `window.confirm` with a designed dialog.
+- Autosave or a local draft cache.
+
+## Decisions
+
+### A capture-phase listener on `window`, not per-link opt-in
+
+The alternative is what exists today: each link calls `confirmLeave()` in its
+`onClick`. It works, and it has already failed — one link out of a dozen adopted
+it, and the dozen live in files the editor has no business editing. Any new link
+anywhere in the chrome would be a new leak.
+
+Capture phase matters, and so does the target being `window` rather than
+`document`. The App Router hydrates the React root into `document`, and React
+attaches its whole synthetic event system as a single listener on that root
+container — so a `document` capture listener registered after hydration runs
+*after* React has dispatched `<Link>`'s own `onClick`, which has already
+`preventDefault`ed and called `router.push`. `window` sits above `document` in
+the capture path and therefore runs first regardless of registration order,
+which is what lets `preventDefault()` stop the navigation instead of racing it.
+
+*Alternative considered:* patching `history.pushState` / monkeypatching the
+router. It catches programmatic navigation too, which the click listener misses,
+but it fires after the decision to navigate has been taken — there is nothing
+left to cancel, only a "navigate back" to fake, and faking it leaves the editor
+remounted with the body gone. Rejected.
+
+### The listener lives as long as the page, and asks about dirtiness inside
+
+Registering only while dirty would keep a global listener off the document for
+the clean case, but the dirty state is derived from a ref the editor writes
+without re-rendering — there is no render to hang the registration on, so it
+would have to be polled or the effect re-run on every keystroke. One listener
+for the page's lifetime, calling `isDirty()` as its first act, costs a set
+membership test per click and cannot be stale. It also unregisters on unmount in
+the same effect cleanup as `beforeunload`, so there is one lifetime to reason
+about rather than two.
+
+### What counts as "leaving"
+
+The handler resolves the clicked element to its closest `a[href]` and only
+prompts when following it would take the browsing context off the current path.
+Everything below stays silent because none of it loses work:
+
+- No anchor in the click's ancestry — a button, the editor toolbar, a tab.
+- An anchor whose resolved `pathname` **and** `search` equal the current one,
+  which covers bare `#` and in-page section links. Comparing the path alone
+  would wave through a query-string change; comparing the whole URL would prompt
+  on a fragment.
+- A modified click — `ctrl`/`cmd`/`shift`/`alt` — or a non-primary button, and a
+  `target` other than `_self`: the page stays open, so nothing is lost.
+- A `download` link, and a `mailto:` / `tel:` / `sms:` / `javascript:` href.
+  These hand the click to something that is not the browsing context.
+- A default-prevented click: something upstream already handled it.
+- A link inside a `contenteditable` — one the author wrote into the body.
+  Clicking it puts the caret in it rather than following it, so prompting would
+  fire on an ordinary edit.
+
+### The breadcrumb stops guarding itself
+
+`confirmLeave` existed so one link could opt in. Now that no link has to, a
+second guard on that one link is two prompts to keep in step and one more way
+for them to diverge. The callback goes with it, so `useLeaveGuard` is called for
+its effect alone and there is exactly one place that decides whether leaving is
+allowed.
+
+### Back and Forward: a sentinel was built, measured and rejected
+
+A `popstate` handler on its own is too late — the entry has already moved, and
+the only recovery is pushing the author forward again, by which point the editor
+has unmounted and taken the body with it. The way round that is a sentinel: push
+a duplicate history entry for the authoring URL, so the first Back press lands
+back on the same page and `popstate` gets to ask before anything is lost. It was
+implemented and driven in a real browser, and it does not ship.
+
+`pushState` discards every forward entry. The sentinel armed on mount, so merely
+opening the editor destroyed the browser's Forward stack — for an author who was
+only reading, who then found Forward dead on a page they had not edited. That is
+a worse bug than the one being fixed, and it is not a detail of the
+implementation: arming is what breaks it. Two smaller holes came with it. A
+multi-step Back — press-and-hold, or several presses faster than the handler
+settles — skips past the sentinel and off the page unasked. And because the
+entry outlives an unmount that races the pop, the guard could leave a stray
+entry on an unrelated page.
+
+So Back and Forward are **not** guarded. Recorded here rather than deleted so
+the next person does not rebuild it and find the same wall.
+
+If someone does revisit it: arm on the first edit, not on mount. A reader never
+pays for the guard then, and an author who has started typing has usually not
+built a Forward stack worth keeping. The multi-step-Back hole would remain, and
+there is no version of a sentinel that closes it — the durable answer for Back
+is autosave, not interception.
+
+### `window.confirm`, not a dialog component
+
+Cancelling a click has to happen in the handler, synchronously. A React dialog
+resolves a promise on a later tick, by which point the navigation has committed.
+The page already confirms deletion with `window.confirm`
+(`ArticleAuthoringPage.tsx:121`), so the ugliness is at least consistent, and
+the prompt string stays in `useLeaveGuard` so `beforeunload` and the click path
+cannot drift apart.
+
+`beforeunload` cannot show custom text at all — every browser replaced it with a
+fixed string years ago — so the two paths were never going to read identically.
+
+### Publish and delete are silent by construction
+
+Both navigate with `router.push` (`useArticleDraft.ts:169,176`), not an anchor,
+so the listener never sees them. That is luck rather than design, and the spec
+pins it as a requirement so a later refactor to a `<Link>` cannot quietly start
+prompting the author after they pressed Publish.
+
+Publishing also saves first, which would leave the page clean; deleting does
+not, and a deleted article's unsaved body is exactly the work the author just
+asked to throw away.
+
+## Risks / Trade-offs
+
+- **A global capture listener can swallow a click it should not.** → It only
+  ever acts on anchors leading off the current path, and only while dirty; every
+  other click falls through untouched. Tests cover the fall-through cases
+  explicitly, not just the prompt case.
+- **`window.confirm` is blocking and ugly, and some environments suppress it.**
+  → Accepted for the reason above. A suppressed `confirm` returns `false` in
+  most browsers, which fails closed: the author stays on the page.
+- **A declined click still runs the link's own `onClick`.** Not calling
+  `stopPropagation` is what lets the drawer and the user menu close behind the
+  dialog, and it has a cost: clicking a notification row in the bell popover and
+  then declining still fires `markArticleRead` and closes the popover
+  (`NotificationsBell.tsx:99-111`). The author keeps their work, which is the
+  point, but the notification is marked read on a navigation that never
+  happened. Accepted — the alternative is menus stuck open behind a cancelled
+  click, on every link in the chrome.
+- **Three exits stay open**: Back and Forward, a toast click, and log out. None
+  is a link the interceptor can see, and the sentinel that would have covered
+  the first is rejected above. → Named in the proposal under Known limitations
+  and in the spec's requirement, and deliberately not written as a SHALL.
+  Guarding the toast or logout means the component asking the editor for
+  permission, which is the opt-in pattern this change removes; the durable
+  answer for all three is autosave.
+- **Two guards say slightly different things.** `beforeunload` shows the
+  browser's fixed wording, the click path shows ours. → Unavoidable; the shared
+  constant keeps ours in one place.
+- **The full flow is awkward to drive end to end.** It needs a logged-in
+  author, a seeded project and a draft, and login is rate-limited to 5 requests
+  per minute per IP (`api/rate_limit.py`). → The click and unload paths are
+  covered by vitest, and the interception mechanism by `e2e/leave-guard.spec.ts`
+  in a real browser. The manual passes against the authenticated editor are
+  still outstanding — see [`tasks.md`](tasks.md).
+
+## Migration Plan
+
+None. Frontend-only, no schema, no contract. Deploying is shipping the build;
+rolling back is reverting it.
+
+## Open Questions
+
+- Whether to autosave the body. It would close the three limitations above,
+  which no click or history guard can reach, and make the rest of this defence
+  in depth rather than the only defence. Out of scope here; the argument for it
+  is stronger after this change than before, because what remains unguarded is
+  now exactly the set of exits no interception can see.

--- a/openspec/changes/guard-unsaved-article-edits/proposal.md
+++ b/openspec/changes/guard-unsaved-article-edits/proposal.md
@@ -1,0 +1,117 @@
+# Guard unsaved article edits
+
+## Why
+
+An author writes half an article, clicks **My Projects** in the header, and the
+text is gone. No prompt, no draft, nothing to go back to. That is
+[issue #84](https://github.com/alexcouper/nglspn/issues/84).
+
+The body is the part that hurts. MDXEditor holds it uncontrolled in a ref
+(`articleDraftState.ts:20`), so between saves it exists only in the page's
+memory — leaving the page is deleting it. The form fields go the same way.
+
+A guard exists but covers one door out of many. `useLeaveGuard`
+(`src/app/projects/[slug]/articles/useLeaveGuard.ts`) registers a `beforeunload`
+listener, which browsers fire only for browser-level navigation, and returns a
+`confirmLeave()` that in-app links are expected to call for themselves. Exactly
+one link calls it: the breadcrumb, at `ArticleAuthoringPage.tsx:152`.
+
+Everything else that navigates is rendered by the root layout as a sibling of
+the page — `Navigation` and `Footer` in `src/app/layout.tsx:73-78`, and inside
+`Navigation` the logo, Projects, Competitions, My Projects, the `UserMenu`
+entries and the `NotificationsBell` links. The page cannot reach into them to
+opt them in, and it should not have to: a guard that depends on every future
+link in the app remembering to ask is a guard that decays.
+
+## What Changes
+
+- **The authoring page guards itself against navigation it does not own.** A
+  capture-phase `click` listener on `window` inspects the anchor a click
+  resolves to. If the draft is dirty and following that anchor would leave the
+  current path, the author is asked to confirm; declining cancels the click and
+  leaves them where they were with the work intact.
+- **The prompt is `window.confirm`**, the same mechanism as the page's existing
+  delete confirmation (`ArticleAuthoringPage.tsx:121`). A custom dialog cannot
+  answer synchronously, and a click can only be cancelled synchronously.
+- **`beforeunload` stays** as the cover for closing the tab, reloading, or
+  typing a new URL. It is the browser's own dialog and nothing else can produce
+  it.
+- **The breadcrumb's own `confirmLeave()` call goes, and so does the callback
+  the hook returned for it.** With the window listener in place it is a second
+  guard on one link out of many — two prompts to keep in step for no coverage
+  the interceptor does not already give.
+- **Clicks that never leave the page stay silent**: a modified or non-primary
+  click, `target` other than `_self`, a `download` link, a `mailto:` / `tel:` /
+  `sms:` / `javascript:` href, any href resolving to the current path and
+  query, and a link the author wrote into the body, where a click puts the caret
+  in it rather than following it.
+- **Deliberate exits stay silent.** Publishing and deleting both `router.push`
+  to the project page (`useArticleDraft.ts:169,176`); neither is an anchor
+  click, so neither reaches the listener, and neither should prompt.
+
+Not breaking: no API, schema, route or contract change. `backend-openapi.json`
+is untouched, and no backend file changes.
+
+### Known limitations
+
+Three exits stay unguarded. Recording them here rather than writing a
+requirement the code does not meet:
+
+- **Back and Forward.** A history sentinel — a duplicate entry pushed while the
+  draft is dirty, so the first Back press lands back on the authoring page and
+  `popstate` can ask — was built and driven in a real browser, and rejected.
+  `pushState` discards all forward entries and the sentinel armed on mount, so
+  merely opening the editor destroyed the Forward stack of every visitor,
+  including one who only read the page. It also missed a multi-step Back and
+  could leave a stray entry on an unrelated page. [`design.md`](design.md)
+  keeps the full reasoning, and the one avenue worth trying if anyone revisits
+  it. Unsaved work is still lost this way.
+- **Clicking a notification in the toaster.** `NotificationToaster.tsx:36`
+  navigates with `router.push`, and the toast body is a `<div onClick>` — there
+  is no anchor for the click interceptor to resolve. Guarding it means the
+  toaster asking the editor, which is the per-component opt-in this change
+  exists to get away from. Unsaved work is still lost this way.
+- **Log out from the user menu.** `logout()` (`contexts/auth.tsx:72`) clears the
+  tokens and the user without navigating; `useRequireAuth` in
+  `ArticleAuthoringRoute` then redirects, unmounting the editor. A button, not a
+  link, so nothing here sees it either.
+
+### Explicitly out of scope
+
+- **Autosave, or persisting the body to `localStorage`.** Either would make
+  most of this unnecessary and both are larger changes with their own failure
+  modes (a draft written to the server the author never asked to save; a local
+  copy that goes stale against a save made in another tab). Not ruled out
+  later; not what #84 asks for.
+- **A styled confirmation dialog.** Wanted eventually, blocked by the
+  synchronous-cancel constraint above.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `articles`: a new requirement, alongside **Authoring endpoint and entry
+  point**, that unsaved work survives an attempt to leave the authoring page by
+  any route the page can observe — including navigation started by the global
+  site chrome the page does not own.
+
+## Impact
+
+**Frontend** (`src/web-ui/`), all under `src/app/projects/[slug]/articles/`
+except the e2e spec:
+
+- `useLeaveGuard.ts` — gains the window-level click interceptor next to the
+  existing `beforeunload` listener, and stops returning `confirmLeave`.
+- `useArticleDraft.ts` — calls the hook for its effect only; `confirmLeave`
+  leaves the returned draft object.
+- `ArticleAuthoringPage.tsx` — the breadcrumb's `onClick` guard goes.
+- `use-leave-guard.test.tsx` — new, covering the interceptor and
+  `beforeunload`.
+- `e2e/leave-guard.spec.ts` — new. It transcribes the interception mechanism
+  onto a public page and checks it in a real browser rather than driving the
+  authenticated editor, so the shipped hook's own behaviour is covered by the
+  unit tests only.
+
+**Not affected**: `Navigation.tsx`, `Footer.tsx`, `layout.tsx` and every other
+component outside the articles directory — the point of putting the listener on
+`window` is that the chrome needs no changes. Backend: none.

--- a/openspec/changes/guard-unsaved-article-edits/specs/articles/spec.md
+++ b/openspec/changes/guard-unsaved-article-edits/specs/articles/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Unsaved work survives an attempt to leave the authoring page
+
+The authoring page holds the article body in the editor's memory until an explicit save, so leaving the page discards it. The authoring page SHALL warn the author before any navigation that would discard unsaved changes, and declining the warning SHALL leave the author on the page with the work intact.
+
+The warning SHALL cover a click on any link in the document, whether or not the page owns it. In particular it SHALL cover the links rendered by the global site chrome — the header, the site logo, the user menu, the notifications bell and the footer — which the root layout renders as siblings of the page. A link SHALL NOT have to opt in to be guarded.
+
+The warning SHALL also cover browser-level navigation away from the page — closing the tab, reloading, or replacing the URL — for which the browser's own unload dialog is the prompt.
+
+Three exits stay unguarded, and are known gaps rather than intended behaviour. Unsaved work is lost without a warning when the author presses the browser's Back or Forward button; when they log out from the user menu, which unmounts the editor by clearing the session rather than by navigating; and when they open a notification from the toaster, which navigates in code rather than through a link. The change's proposal records why each is out of reach of the mechanisms this requirement is built on.
+
+"Unsaved changes" SHALL mean the same comparison a save would write: the editor body plus every editable field against the article the server last returned. A page in step with the server SHALL NOT warn, and neither SHALL a click that keeps the author on the page — a control that is not a link, a link to the current path or a bare fragment, a link opened in a new tab, or a click already handled elsewhere.
+
+Navigation that concludes the editing session at the author's own instruction SHALL NOT warn: the move to the project page after publishing the article, and the move to the project page after deleting it.
+
+#### Scenario: Header link warns while the article is dirty
+- **GIVEN** an author on the authoring page who has typed into the editor since the last save
+- **WHEN** they click a header, logo, user-menu, notifications or footer link that leads off the authoring path
+- **THEN** they SHALL be asked to confirm leaving without saving
+
+#### Scenario: Declining the warning keeps the author and the work
+- **GIVEN** an author who has been asked to confirm leaving
+- **WHEN** they decline
+- **THEN** the navigation SHALL NOT happen and the editor SHALL still hold the unsaved body and fields
+
+#### Scenario: Accepting the warning leaves the page
+- **GIVEN** an author who has been asked to confirm leaving
+- **WHEN** they accept
+- **THEN** the navigation SHALL proceed to the link's destination
+
+#### Scenario: A clean page never warns
+- **GIVEN** an author whose article matches what the server last returned
+- **WHEN** they click any link that leaves the authoring page
+- **THEN** they SHALL leave with no prompt
+
+#### Scenario: Closing or reloading the tab while dirty warns
+- **GIVEN** an author on the authoring page with unsaved changes
+- **WHEN** they close the tab, reload, or navigate the browser to another URL
+- **THEN** the browser SHALL present its unload confirmation before the page is discarded
+
+#### Scenario: Publishing does not warn
+- **GIVEN** an author on the authoring page
+- **WHEN** they publish the article and the page moves them to the project page
+- **THEN** no leave confirmation SHALL be shown
+
+#### Scenario: Deleting does not warn
+- **GIVEN** an author on the authoring page with unsaved changes
+- **WHEN** they confirm the delete and the page moves them to the project page
+- **THEN** no leave confirmation SHALL be shown beyond the delete confirmation itself
+
+#### Scenario: Staying on the page does not warn
+- **GIVEN** an author on the authoring page with unsaved changes
+- **WHEN** they click a control that does not leave the page — a button, an editor tab, a link to the current path, a link opened in a new tab or window, a download link, or a link the browser hands to another application
+- **THEN** no leave confirmation SHALL be shown

--- a/openspec/changes/guard-unsaved-article-edits/tasks.md
+++ b/openspec/changes/guard-unsaved-article-edits/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: guard unsaved article edits
+
+## 1. Extend the leave guard to navigation the page does not own
+
+- [x] 1.1 In `src/web-ui/src/app/projects/[slug]/articles/useLeaveGuard.ts`, add a
+  `click` listener on `window` in the **capture** phase, in the same effect as
+  the existing `beforeunload` listener and torn down with it.
+- [x] 1.2 Return immediately when the event's default is already prevented or
+  `isDirty()` is false, so a clean page and an already-handled click cost one
+  call.
+- [x] 1.3 Resolve `event.target` to its closest `a[href]` and return when there is
+  none.
+- [x] 1.4 Add an `isLeavingClick` predicate covering the cases that keep the
+  author on the page: a non-primary button; `ctrlKey` / `metaKey` / `shiftKey` /
+  `altKey`; a `target` other than `_self`; a `download` attribute; a `mailto:`,
+  `tel:`, `sms:` or `javascript:` scheme; an href that fails to parse; and a
+  destination whose `pathname` and `search` both match the current URL's.
+- [x] 1.5 Exclude links inside a `contenteditable`. Clicking one the author wrote
+  into the body puts the caret in it rather than following it, so prompting there
+  would fire on an ordinary edit. Match the attribute, not `isContentEditable`,
+  which jsdom does not compute.
+- [x] 1.6 Otherwise prompt with the existing `LEAVE_PROMPT` via `window.confirm`,
+  and on a decline call `preventDefault()` — and **not** `stopPropagation()`.
+  `Link` runs the anchor's own `onClick` before bailing on `defaultPrevented`, so
+  cancelling the default stops the navigation while the drawer and the user menu
+  still close behind the dialog.
+- [x] 1.7 Set `event.returnValue = ""` in the `beforeunload` handler alongside the
+  `preventDefault()`, for the older Safari spelling.
+- [x] 1.8 Drop the returned `confirmLeave` callback, the breadcrumb's `onClick`
+  guard in `ArticleAuthoringPage.tsx`, and `confirmLeave` from the object
+  `useArticleDraft` returns. One guard, in one place.
+- [x] 1.9 Record in a comment why the listener sits on `window` and not
+  `document`: React attaches its synthetic event system to the hydration root on
+  `document`, so a `document` capture listener would run after `<Link>`'s own
+  `onClick` had already called `router.push`.
+
+## 2. Tests
+
+- [x] 2.1 Add `src/web-ui/src/app/projects/[slug]/articles/use-leave-guard.test.tsx`,
+  rendering the hook with a controllable `isDirty` and a stubbed
+  `window.confirm`.
+- [x] 2.2 Dirty, a link off the current path: declining cancels the navigation,
+  confirming lets it through.
+- [x] 2.3 A declined click still reaches the link's own handlers, which is what
+  keeps the menus closing.
+- [x] 2.4 A click on an element nested inside the link still prompts; a click that
+  hit no link at all does not; an already-cancelled click is left alone.
+- [x] 2.5 Clean draft: never asks.
+- [x] 2.6 The silent cases from 1.4 and 1.5, one assertion each — each modifier
+  key, a non-primary button, another tab, a download, a `mailto:`, a bare hash, a
+  section link on this page, a link inside the body.
+- [x] 2.7 `beforeunload` warns while dirty and stays quiet while clean.
+- [x] 2.8 After unmount, neither clicks nor unloads are guarded.
+- [x] 2.9 Add `src/web-ui/e2e/leave-guard.spec.ts`, checking in a real browser
+  that `preventDefault` alone cancels an App Router `Link`. It transcribes the
+  interception onto a public page rather than driving the authenticated editor.
+  Keep it out of CI, as the rest of `e2e/` is.
+
+## 3. Verify
+
+- [x] 3.1 `make lint` and `make test` in `src/web-ui/` — lint clean, full vitest
+  suite passing.
+- [x] 3.2 `npx playwright test e2e/leave-guard.spec.ts` — both tests pass in
+  Chrome.
+- [ ] 3.3 `make build-app` and `make extra-tests` in `src/web-ui/` — the bundle
+  budgets are per route and this adds code to the authoring route.
+- [ ] 3.4 **Blocked — nobody has driven the real editor in a browser.** The
+  credentials in `.env.claude` 401 against the local backend, and only one dev
+  account has `full_edit`, so none of the manual passes below has been run. The
+  shipped hook's own behaviour rests on the unit tests until someone with a
+  working authoring account works through them:
+  - the reported bug: open a draft, type into the body, click **My Projects** in
+    the header; the prompt appears, declining keeps the typed text, accepting
+    leaves;
+  - the quiet cases: with unsaved text, switch editor tabs and open a link in a
+    new tab — neither prompts; save, then click a header link — no prompt;
+  - the deliberate exits: publish an article, and separately delete one, and
+    neither shows a leave prompt on the way to the project page;
+  - hard navigation: with unsaved text, reload the tab and the browser's own
+    warning still fires;
+  - the three known limitations still read true — Back, a toast click and **Log
+    out** all leave without a prompt — so the proposal describes what ships.

--- a/src/web-ui/e2e/leave-guard.spec.ts
+++ b/src/web-ui/e2e/leave-guard.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The part of the article leave guard that jsdom cannot answer: whether a
+// window-capture listener that only cancels the default really stops an App
+// Router `Link`, with React's own event plumbing in the way.
+//
+// These tests do not drive the article editor. It needs a login, so the guard's
+// click interceptor is transcribed here onto a public page and exercised there;
+// what the editor does with the verdict is covered by
+// `src/app/projects/[slug]/articles/use-leave-guard.test.tsx`.
+//
+// Needs a running Next dev server (`make dev` in src/web-ui). Not in CI, like
+// the rest of `e2e/`.
+//
+// `SPIKE_APP_URL`, not `TEST_APP_URL`: `playwright.config.ts` parses
+// `.env.claude` after the environment and overwrites `TEST_APP_URL` with
+// whatever that file says, so it cannot be overridden from the command line.
+// The port matters — `make dev` takes the first free port from 3000, so a
+// second checkout running its own server is not on 3000.
+const BASE = process.env.SPIKE_APP_URL ?? "http://localhost:3000";
+
+// The feed streams in behind a Suspense boundary, so waiting for a row waits
+// well past the point where the nav alone has rendered.
+const feedRow = (page: Page) =>
+  page.locator("main a[href^='/projects/']").first();
+
+const siteLink = (page: Page) => page.locator("a[href='/projects']").first();
+
+async function openHydrated(page: Page) {
+  await page.goto(`${BASE}/latest`);
+  await expect(feedRow(page)).toBeAttached({ timeout: 20_000 });
+  await page.waitForTimeout(800);
+}
+
+// ------------------------------------------------- the click interceptor
+
+// The guard's click interceptor, transcribed: a capture listener registered
+// long after hydration that cancels the default and nothing else.
+async function refuseLinkClicks(page: Page, on: "window" | "document") {
+  await page.evaluate((target) => {
+    const host = target === "window" ? window : document;
+    const flags = window as unknown as { __saw: boolean; __bubbled: boolean };
+    flags.__saw = false;
+    flags.__bubbled = false;
+    // Records that the click carried on past the interceptor, which is what
+    // lets a menu link still run its own `closeMenu`.
+    document.addEventListener("click", () => {
+      flags.__bubbled = true;
+    });
+    host.addEventListener(
+      "click",
+      (event) => {
+        if (!(event.target as Element | null)?.closest?.("a[href]")) return;
+        flags.__saw = true;
+        event.preventDefault();
+      },
+      true,
+    );
+  }, on);
+}
+
+async function clickSiteLink(page: Page) {
+  await siteLink(page).click();
+  await page.waitForTimeout(1200);
+  return {
+    url: page.url(),
+    ...(await page.evaluate(() => {
+      const flags = window as unknown as { __saw: boolean; __bubbled: boolean };
+      return { saw: flags.__saw, bubbled: flags.__bubbled };
+    })),
+  };
+}
+
+test("preventDefault alone cancels an App Router Link", async ({ page }) => {
+  await openHydrated(page);
+  await refuseLinkClicks(page, "window");
+
+  const result = await clickSiteLink(page);
+
+  expect(result.saw).toBe(true);
+  expect(result.url).toContain("/latest");
+  // No `stopPropagation`: `Link` bails on `defaultPrevented`, and the click
+  // still reaches the handlers that close the drawer and the user menu.
+  expect(result.bubbled).toBe(true);
+});
+
+// Measured, not assumed. `app-index.js` hydrates the root into `document`, so
+// it would be reasonable to expect a document-capture listener to lose to
+// React's delegated one — it does not, in Next 16.1.6. The guard still uses
+// `window`, because that is the one position in the capture path that no other
+// listener and no React version can get in front of.
+test("a document-capture listener happens to cancel it too", async ({
+  page,
+}) => {
+  await openHydrated(page);
+  await refuseLinkClicks(page, "document");
+
+  const result = await clickSiteLink(page);
+
+  expect(result.saw).toBe(true);
+  expect(result.url).toContain("/latest");
+});

--- a/src/web-ui/src/app/projects/[slug]/articles/ArticleAuthoringPage.tsx
+++ b/src/web-ui/src/app/projects/[slug]/articles/ArticleAuthoringPage.tsx
@@ -146,11 +146,6 @@ export function ArticleAuthoringPage({ project, articleId }: Props) {
             <Link
               href={`/my-projects/${project.id}#articles`}
               className="hover:text-foreground"
-              onClick={(e) => {
-                // The body is only in memory until a save, so leaving by the
-                // breadcrumb is as lossy as closing the tab.
-                if (!draft.confirmLeave()) e.preventDefault();
-              }}
             >
               {project.title}
             </Link>

--- a/src/web-ui/src/app/projects/[slug]/articles/use-article-draft.test.tsx
+++ b/src/web-ui/src/app/projects/[slug]/articles/use-article-draft.test.tsx
@@ -491,3 +491,16 @@ describe("unsaved changes", () => {
     await harness.unmount();
   });
 });
+
+describe("the deliberate exits", () => {
+  it("does not sweep the article again on the unmount that follows", async () => {
+    const harness = await mountDraft({ articleId: "article-1" });
+
+    await harness.act(async () => {
+      await harness.draft().remove();
+    });
+    await harness.unmount();
+
+    expect(articles.delete).toHaveBeenCalledOnce();
+  });
+});

--- a/src/web-ui/src/app/projects/[slug]/articles/use-leave-guard.test.tsx
+++ b/src/web-ui/src/app/projects/[slug]/articles/use-leave-guard.test.tsx
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { LEAVE_PROMPT, useLeaveGuard } from "./useLeaveGuard";
+
+// --------------------------------------------------------------- factories
+
+function anchor(attributes: Record<string, string>) {
+  const element = document.createElement("a");
+  for (const [name, value] of Object.entries(attributes)) {
+    element.setAttribute(name, value);
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+function link(href: string) {
+  return anchor({ href });
+}
+
+// ---------------------------------------------------------------- firing
+
+// The guard's verdict on a click, without letting jsdom try to follow the link.
+//
+// The observer goes on window in the capture phase, registered after the hook's
+// own listener, so it always runs second and sees whatever verdict the guard
+// reached. `stopPropagation` does not silence it: that only stops the event
+// moving on to the next target, not the remaining listeners on this one.
+function clickIsAllowed(element: Element, init: MouseEventInit = {}) {
+  let prevented = false;
+  const observe = (event: Event) => {
+    prevented = event.defaultPrevented;
+    event.preventDefault();
+  };
+  window.addEventListener("click", observe, true);
+  element.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true, ...init }),
+  );
+  window.removeEventListener("click", observe, true);
+  return !prevented;
+}
+
+// jsdom's legacy `Event.returnValue` setter coerces to a boolean and
+// preventDefaults on anything falsy, which would hide whether the guard set it
+// at all. A plain property in its place records the assignment for what it is.
+function fireBeforeUnload() {
+  const event = new Event("beforeunload", { cancelable: true });
+  let returnValue: unknown;
+  Object.defineProperty(event, "returnValue", {
+    configurable: true,
+    get: () => returnValue,
+    set: (value) => {
+      returnValue = value;
+    },
+  });
+  window.dispatchEvent(event);
+  return { prevented: event.defaultPrevented, returnValue };
+}
+
+// ---------------------------------------------------------------- mounting
+
+function Harness({ isDirty }: { isDirty: () => boolean }) {
+  useLeaveGuard(isDirty);
+  return null;
+}
+
+// Torn down in afterEach rather than by each test, so that a failed assertion
+// cannot leave a guard listening on window and fail the next test instead.
+const mounted: Array<() => Promise<void>> = [];
+
+async function mountGuard({ dirty = true }: { dirty?: boolean } = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<Harness isDirty={() => dirty} />);
+  });
+
+  const unmount = async () => {
+    const pending = mounted.indexOf(unmount);
+    if (pending === -1) return;
+    mounted.splice(pending, 1);
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  };
+  mounted.push(unmount);
+  return { unmount };
+}
+
+async function unmountAll() {
+  while (mounted.length) await mounted[0]();
+}
+
+// ---------------------------------------------------------------- the tests
+
+function stubConfirm(answer: boolean) {
+  return vi.spyOn(window, "confirm").mockReturnValue(answer);
+}
+
+// The author says yes unless a test says otherwise; the interesting cases are
+// the ones where nothing asks at all.
+let confirmed: ReturnType<typeof stubConfirm>;
+
+beforeEach(() => {
+  confirmed = stubConfirm(true);
+});
+
+afterEach(async () => {
+  await unmountAll();
+  document.body.replaceChildren();
+});
+
+describe("clicking a link while the draft is dirty", () => {
+  it("cancels the navigation when the author declines", async () => {
+    confirmed.mockReturnValue(false);
+    await mountGuard();
+
+    expect(clickIsAllowed(link("/my-projects/project-1"))).toBe(false);
+    expect(confirmed).toHaveBeenCalledOnce();
+  });
+
+  it("lets the navigation through when the author confirms", async () => {
+    await mountGuard();
+
+    expect(clickIsAllowed(link("/my-projects/project-1"))).toBe(true);
+    expect(confirmed).toHaveBeenCalledOnce();
+  });
+
+  // `Link` bails on `e.defaultPrevented`, but only after running the anchor's
+  // own onClick — which is how the mobile drawer and the user menu close
+  // themselves. Cancelling the default must not cost them that.
+  it("lets a declined click still reach the link's own handlers", async () => {
+    confirmed.mockReturnValue(false);
+    await mountGuard();
+    const closeMenu = vi.fn();
+    const target = link("/latest");
+    target.addEventListener("click", closeMenu);
+
+    expect(clickIsAllowed(target)).toBe(false);
+    expect(closeMenu).toHaveBeenCalledOnce();
+  });
+
+  it("prompts for a click on anything nested inside the link", async () => {
+    confirmed.mockReturnValue(false);
+    await mountGuard();
+    const nested = document.createElement("span");
+    link("/latest").appendChild(nested);
+
+    expect(clickIsAllowed(nested)).toBe(false);
+  });
+
+  it("says nothing about a click that missed every link", async () => {
+    await mountGuard();
+    const button = document.body.appendChild(document.createElement("button"));
+
+    expect(clickIsAllowed(button)).toBe(true);
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+
+  it("leaves an already-cancelled click alone", async () => {
+    await mountGuard();
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    event.preventDefault();
+
+    link("/latest").dispatchEvent(event);
+
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+});
+
+describe("clicking a link while the draft is clean", () => {
+  it("never asks", async () => {
+    await mountGuard({ dirty: false });
+
+    expect(clickIsAllowed(link("/my-projects/project-1"))).toBe(true);
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+});
+
+describe("clicks that are not the author leaving the page", () => {
+  const openedElsewhere: Array<[string, MouseEventInit]> = [
+    ["a command-click", { metaKey: true }],
+    ["a control-click", { ctrlKey: true }],
+    ["a shift-click", { shiftKey: true }],
+    ["an alt-click", { altKey: true }],
+    ["a middle-click", { button: 1 }],
+  ];
+
+  for (const [name, init] of openedElsewhere) {
+    it(`ignores ${name}, which does not take the author off the page`, async () => {
+      await mountGuard();
+
+      expect(clickIsAllowed(link("/latest"), init)).toBe(true);
+      expect(confirmed).not.toHaveBeenCalled();
+    });
+  }
+
+  it("ignores a link that opens in another tab", async () => {
+    await mountGuard();
+
+    expect(clickIsAllowed(anchor({ href: "/latest", target: "_blank" }))).toBe(
+      true,
+    );
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+
+  it("ignores a download link", async () => {
+    await mountGuard();
+
+    expect(
+      clickIsAllowed(anchor({ href: "/export.csv", download: "export.csv" })),
+    ).toBe(true);
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+
+  it("ignores a link the author wrote into the body", async () => {
+    await mountGuard();
+    const body = document.body.appendChild(document.createElement("div"));
+    body.setAttribute("contenteditable", "true");
+    const written = document.createElement("a");
+    written.setAttribute("href", "/somewhere-else");
+    body.appendChild(written);
+
+    expect(clickIsAllowed(written)).toBe(true);
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+
+  it("ignores a mailto: link", async () => {
+    await mountGuard();
+
+    expect(clickIsAllowed(link("mailto:hello@example.com"))).toBe(true);
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+
+  it("ignores a bare hash", async () => {
+    await mountGuard();
+
+    expect(clickIsAllowed(link("#"))).toBe(true);
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+
+  it("ignores a link to a section of this same page", async () => {
+    await mountGuard();
+
+    expect(clickIsAllowed(link(`${window.location.pathname}#images`))).toBe(
+      true,
+    );
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+});
+
+describe("closing the tab", () => {
+  it("asks the browser to warn while the draft is dirty", async () => {
+    await mountGuard();
+
+    // `returnValue` is the old Safari spelling of the same intent, and only
+    // counts for a non-empty string; current browsers read the preventDefault.
+    expect(fireBeforeUnload()).toEqual({
+      prevented: true,
+      returnValue: LEAVE_PROMPT,
+    });
+  });
+
+  it("stays out of the way while the draft is clean", async () => {
+    await mountGuard({ dirty: false });
+
+    expect(fireBeforeUnload()).toEqual({
+      prevented: false,
+      returnValue: undefined,
+    });
+  });
+});
+
+describe("after the editor is gone", () => {
+  it("guards neither clicks nor unloads", async () => {
+    const guard = await mountGuard();
+    await guard.unmount();
+
+    expect(clickIsAllowed(link("/latest"))).toBe(true);
+    expect(fireBeforeUnload().prevented).toBe(false);
+    expect(confirmed).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/app/projects/[slug]/articles/useArticleDraft.ts
+++ b/src/web-ui/src/app/projects/[slug]/articles/useArticleDraft.ts
@@ -126,7 +126,7 @@ export function useArticleDraft({ project, articleId }: Options) {
     () => fieldsAreDirty(article),
     [fieldsAreDirty, article],
   );
-  const confirmLeave = useLeaveGuard(isDirty);
+  useLeaveGuard(isDirty);
 
   // The wizard's outcome: an image and the rectangle the author drew on it.
   // Any choice commits the mode, so the next save does not re-derive the image
@@ -194,7 +194,6 @@ export function useArticleDraft({ project, articleId }: Options) {
     updateForm: updateFields,
     snapshotForm: snapshot,
     isDirty,
-    confirmLeave,
     chooseListingImage,
     removeListingImage,
     save,

--- a/src/web-ui/src/app/projects/[slug]/articles/useLeaveGuard.ts
+++ b/src/web-ui/src/app/projects/[slug]/articles/useLeaveGuard.ts
@@ -1,29 +1,98 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 
-const LEAVE_PROMPT =
+// Exported so the test can assert on the sentence the guard shows rather than
+// on a second copy of it.
+export const LEAVE_PROMPT =
   "You have unsaved changes to this article. Leave without saving?";
 
-// Guards against leaving with unsaved work, by both routes out of the page.
+// Schemes that hand the click to something other than the browsing context.
+const NON_NAVIGATING = new Set(["mailto:", "tel:", "sms:", "javascript:"]);
+
+// True when the click is the author leaving the page, rather than opening the
+// link somewhere else or moving around inside this one.
+function isLeavingClick(event: MouseEvent, anchor: HTMLAnchorElement) {
+  // A modified click opens a new tab or window, and a non-primary button is
+  // not a navigation at all — the author stays where they are either way.
+  if (event.button !== 0) return false;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+    return false;
+
+  const target = anchor.getAttribute("target");
+  if (target && target !== "_self") return false;
+  if (anchor.hasAttribute("download")) return false;
+
+  // A link the author wrote into the body. Clicking one inside a contenteditable
+  // puts the caret in it rather than following it, so prompting would fire on
+  // an ordinary edit. Matched by attribute rather than `isContentEditable`,
+  // which jsdom does not compute.
+  if (anchor.closest('[contenteditable]:not([contenteditable="false"])'))
+    return false;
+
+  const href = anchor.getAttribute("href");
+  if (!href) return false;
+
+  let destination: URL;
+  try {
+    destination = new URL(href, window.location.href);
+  } catch {
+    return false;
+  }
+  if (NON_NAVIGATING.has(destination.protocol)) return false;
+
+  // A bare "#" or an in-page anchor only moves the scroll position.
+  const here = new URL(window.location.href);
+  return (
+    destination.pathname !== here.pathname || destination.search !== here.search
+  );
+}
+
+// Guards against leaving with unsaved work.
 //
-// The `beforeunload` listener covers browser navigation only — a closed tab, a
-// reload, a typed URL. In-app navigation never fires it, so the links that leave
-// the editor call `confirmLeave` for themselves; the prompt lives here so both
-// halves say the same thing.
+// The `beforeunload` listener covers browser navigation — a closed tab, a
+// reload, a typed URL. In-app navigation never fires it, so the click
+// interceptor covers the rest: every link on the page, including the header,
+// the logo, the user menu and the footer, which `app/layout.tsx` renders as
+// siblings of this page and which therefore know nothing about the draft.
+//
+// The interceptor is registered on `window`, and that is not incidental. React
+// attaches its whole synthetic event system as listeners on the container it
+// hydrated into, and `Link`'s own onClick is what preventDefaults and calls
+// `router.push` — so the guard has to see the click, and cancel it, before
+// React dispatches. `window` is the outermost object in the capture path, above
+// both `document` and any container inside it, so a window-capture listener
+// runs first however late it was registered and wherever React attached. Any
+// listener further in is a bet on React's internals. Do not move it inwards.
 export function useLeaveGuard(isDirty: () => boolean) {
   useEffect(() => {
     const warn = (event: BeforeUnloadEvent) => {
       if (!isDirty()) return;
       event.preventDefault();
+      // The spelling older Safari still reads, which only takes effect for a
+      // non-empty string; current browsers take the preventDefault above.
+      event.returnValue = LEAVE_PROMPT;
     };
-    window.addEventListener("beforeunload", warn);
-    return () => window.removeEventListener("beforeunload", warn);
-  }, [isDirty]);
 
-  // True when it is fine to go: nothing to lose, or the author said so.
-  return useCallback(
-    () => !isDirty() || window.confirm(LEAVE_PROMPT),
-    [isDirty],
-  );
+    const intercept = (event: MouseEvent) => {
+      if (event.defaultPrevented || !isDirty()) return;
+      const anchor = (event.target as Element | null)?.closest?.("a[href]") as
+        HTMLAnchorElement | null | undefined;
+      if (!anchor || !isLeavingClick(event, anchor)) return;
+      if (window.confirm(LEAVE_PROMPT)) return;
+      // Enough on its own, and deliberately not paired with `stopPropagation`.
+      // `Link` runs the anchor's own onClick first and only then bails on
+      // `e.defaultPrevented` (next/dist/client/app-dir/link.js), so cancelling
+      // the default stops the navigation while the drawer and the user menu
+      // still get their `closeMenu` and shut behind the dialog.
+      event.preventDefault();
+    };
+
+    window.addEventListener("beforeunload", warn);
+    window.addEventListener("click", intercept, true);
+    return () => {
+      window.removeEventListener("beforeunload", warn);
+      window.removeEventListener("click", intercept, true);
+    };
+  }, [isDirty]);
 }


### PR DESCRIPTION
Closes #84.

## The bug

The article editor keeps the body in MDXEditor's memory until an explicit save, so leaving the page discards it. A guard existed, but it covered `beforeunload` plus exactly one link — the breadcrumb — which opted in by calling `confirmLeave()`.

`Navigation` and `Footer` are rendered by the root layout as *siblings* of the page, so the header, logo, user menu, notifications bell and footer all navigated away with no prompt at all. That is what the issue reports.

## The fix

The page now guards itself, instead of each link opting in: a capture-phase `click` listener on `window` cancels any anchor click that would leave the current path while the draft is dirty. No global chrome file changes, and links added to the header later are covered for free. `confirmLeave` and the breadcrumb's hand-rolled guard are removed — with the interceptor in place they were a second prompt on one link out of a dozen.

The listener is on `window` rather than `document` deliberately: it is the outermost node in the capture path, so it runs before React dispatches, wherever React attached its synthetic event system.

Links the author wrote into the body are excluded. MDXEditor renders authored markdown links as real `<a href>` inside the contenteditable, so without that exclusion the guard would prompt on an ordinary edit.

`beforeunload` stays for tab close, reload and typed URLs.

## Back and Forward are not guarded

A history sentinel was built, measured in a real browser, and rejected. `pushState` discards all forward entries, and the sentinel armed on mount — so merely opening the editor broke the **Forward** button for every visitor, including one who only reads. Unfixable in that shape, and a multi-step Back skipped past it regardless. The rejected design is recorded in the change's design notes so it is not rebuilt; arming on first edit is the avenue if anyone revisits it.

Two other exits stay unguarded and are recorded as known gaps: logging out (clears the session without navigating, so the editor unmounts) and notification-toaster clicks (`router.push` from a `<div onClick>`, so there is no anchor to intercept).

## Verification

- `npm run lint` — exit 0, no warnings
- `npx vitest run` — 311 passed
- `npx playwright test e2e/leave-guard.spec.ts` — 2 passed in real Chrome
- `make extra-tests` — all 34 routes within budget
- `npx openspec validate guard-unsaved-article-edits --strict` — valid

**Not verified:** nobody has driven the authenticated editor in a browser. The credentials in `.env.claude` 401 against the local backend and only one dev account has `full_edit`, so the e2e tests transcribe the interception mechanism onto a public page rather than exercising the editor wiring. Worth a manual pass before merge: type a headline, click **My Projects** in the header, confirm the prompt appears and that declining keeps the text.

## Note for a follow-up

`playwright.config.ts:12` writes `.env.claude` into `process.env` *after* the environment exists, so `TEST_APP_URL=... npx playwright test` is silently ignored — while CLAUDE.md instructs exactly that. The new e2e spec uses `SPIKE_APP_URL` to sidestep it. Not fixed here.
