### PR TITLE
Keep the article editor toolbar clear of the page's sticky chrome

### DIFF
--- a/src/web-ui/e2e/article-images.spec.ts
+++ b/src/web-ui/e2e/article-images.spec.ts
@@ -1,143 +1,26 @@
 import { test, expect, type Page } from "@playwright/test";
 import * as path from "path";
+import {
+  allowLeavingTheEditor,
+  API_URL,
+  cleanUp,
+  editorBody,
+  fetchArticle,
+  imagePicker,
+  login,
+  openBlankArticleEditor,
+  trackUploadedImageIds,
+} from "./helpers";
 
 const FIXTURES = path.join(__dirname, "fixtures");
 const INLINE_IMAGE = path.join(FIXTURES, "inline-image.png");
 const NOT_AN_IMAGE = path.join(FIXTURES, "not-an-image.txt");
 
-async function login(page: Page) {
-  const password = process.env.TEST_USER_PASSWORD;
-  if (!password) {
-    throw new Error(
-      "TEST_USER_PASSWORD not set. Make sure .env.claude exists with credentials.",
-    );
-  }
-
-  await page.goto("/login");
-  await page.fill("#email", process.env.TEST_USER_EMAIL || "test@example.com");
-  await page.fill("#password", password);
-  await page.click('button[type="submit"]');
-  await expect(page).toHaveURL(/\/my-projects/);
-}
-
-// Walks from the project list to a blank article editor, so the test doesn't
-// hard-code a project slug. The New article button creates the draft — an
-// upload cannot name an article that does not exist yet — and routes straight
-// to its editor, so this returns both ids.
-async function openBlankArticleEditor(
-  page: Page,
-): Promise<{ projectId: string; articleId: string }> {
-  await page.goto("/my-projects");
-  await page.locator('a[href^="/my-projects/"]').last().click();
-  await expect(page).toHaveURL(/\/my-projects\/[0-9a-f-]+$/);
-  const projectId = page.url().split("/").pop()!;
-
-  // The button lives behind a tab, and it is the thing that creates the draft —
-  // there is no route to navigate to instead.
-  await page.getByRole("button", { name: "Articles", exact: true }).click();
-  await page.getByRole("button", { name: "New article" }).click();
-  await expect(page).toHaveURL(/\/articles\/edit\/[0-9a-f-]+$/);
-  await expect(editorBody(page)).toBeVisible();
-
-  return { projectId, articleId: page.url().split("/").pop()! };
-}
-
-// Article uploads are excluded from `project.images`, so cleanup cannot find
-// them by listing the project. Record the ids the backend hands out instead.
-function trackUploadedImageIds(page: Page): string[] {
-  const ids: string[] = [];
-  page.on("response", async (response) => {
-    if (!response.url().endsWith("/images/upload-url") || !response.ok()) return;
-    const body = await response.json().catch(() => null);
-    if (body?.image_id) ids.push(body.image_id);
-  });
-  return ids;
-}
-
-// Deleting the draft cascades its linked images, but the ids are tracked and
-// deleted too so a failure part-way through still cleans up. Every test now
-// leaves a draft behind, because opening the editor creates one.
-async function cleanUp(
-  page: Page,
-  projectId: string,
-  articleId: string,
-  imageIds: string[],
-) {
-  await page.evaluate(
-    async ({ projectId, articleId, imageIds }) => {
-      const apiUrl = "http://localhost:8000";
-      const headers = {
-        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
-      };
-
-      await Promise.all(
-        imageIds.map((imageId: string) =>
-          fetch(
-            `${apiUrl}/api/projects/${projectId}/articles/${articleId}/images/${imageId}`,
-            { method: "DELETE", headers },
-          ),
-        ),
-      );
-      await fetch(`${apiUrl}/api/projects/${projectId}/articles/${articleId}`, {
-        method: "DELETE",
-        headers,
-      });
-    },
-    { projectId, articleId, imageIds: imageIds.splice(0) },
-  );
-}
-
-// The images linked to an article — the listing-image wizard's selection list.
-async function articleImageIds(
-  page: Page,
-  projectId: string,
-  articleId: string,
-): Promise<string[]> {
-  return page.evaluate(
-    async ({ projectId, articleId }) => {
-      const article = await fetch(
-        `http://localhost:8000/api/projects/${projectId}/articles/${articleId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("access_token")}`,
-          },
-        },
-      ).then((r) => r.json());
-      return (article.images ?? []).map((image: { id: string }) => image.id);
-    },
-    { projectId, articleId },
-  );
-}
-
-// The gallery an author manages on the owner-facing project page.
-async function galleryImageIds(
-  page: Page,
-  projectId: string,
-): Promise<string[]> {
-  return page.evaluate(async (projectId) => {
-    const project = await fetch(
-      `http://localhost:8000/api/my/projects/${projectId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("access_token")}`,
-        },
-      },
-    ).then((r) => r.json());
-    return (project.images ?? []).map((image: { id: string }) => image.id);
-  }, projectId);
-}
-
-function editorBody(page: Page) {
-  return page.locator('[contenteditable="true"]').first();
-}
+// One login for the file: /api/auth/login allows 5/min per IP.
+test.describe.configure({ mode: "serial" });
 
 function insertedImage(page: Page) {
   return editorBody(page).locator("img").first();
-}
-
-// The toolbar's insert button drives a hidden file input rather than a dialog.
-function imagePicker(page: Page) {
-  return page.locator('.mdxeditor input[type="file"]').first();
 }
 
 // Next renders its own empty role="alert" route announcer, so pick ours out by
@@ -146,20 +29,33 @@ function uploadAlert(page: Page) {
   return page.getByRole("alert").filter({ hasText: "Image upload failed" });
 }
 
-// Login is rate limited to 5/minute per IP, so the whole file shares one
-// session rather than logging in per test.
-test.describe.configure({ mode: "serial" });
+// The images linked to an article — the listing-image wizard's selection list.
+async function articleImageIds(
+  page: Page,
+  projectId: string,
+  articleId: string,
+): Promise<string[]> {
+  const article = await fetchArticle(page, projectId, articleId);
+  const images = (article.images ?? []) as { id: string }[];
+  return images.map((image) => image.id);
+}
 
-// The editor guards against losing an unsaved body, so navigating away from it
-// raises a beforeunload prompt. Every navigation in these tests is deliberate.
-function allowLeavingTheEditor(page: Page) {
-  page.on("dialog", (dialog) => {
-    if (dialog.type() === "beforeunload") {
-      void dialog.accept();
-    } else {
-      void dialog.dismiss();
-    }
-  });
+// The gallery an author manages on the owner-facing project page.
+async function galleryImageIds(
+  page: Page,
+  projectId: string,
+): Promise<string[]> {
+  return page.evaluate(
+    async ({ apiUrl, projectId }) => {
+      const project = await fetch(`${apiUrl}/api/my/projects/${projectId}`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+        },
+      }).then((r) => r.json());
+      return (project.images ?? []).map((image: { id: string }) => image.id);
+    },
+    { apiUrl: API_URL, projectId },
+  );
 }
 
 test.describe("Article inline images", () => {

--- a/src/web-ui/e2e/article-link-dialog.spec.ts
+++ b/src/web-ui/e2e/article-link-dialog.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  allowLeavingTheEditor,
+  cleanUp,
+  editorBody,
+  login,
+  openBlankArticleEditor,
+} from "./helpers";
+
+const LINK_BUTTON = 'button[aria-label="Create link"]';
+const LINK_DIALOG = '[class*="linkDialogPopoverContent"]';
+
+// One login for the file: /api/auth/login allows 5/min per IP.
+test.describe.configure({ mode: "serial" });
+
+async function typeParagraphs(page: Page, count: number) {
+  await editorBody(page).click();
+  for (let index = 0; index < count; index++) {
+    await page.keyboard.type(
+      `Paragraph number ${index} with some words in it.`,
+    );
+    await page.keyboard.press("Enter");
+  }
+}
+
+// What a click at the button's centre would land on. `toBeVisible` does not
+// catch this: an element covered by the site header is still visible to
+// Playwright.
+async function centreOfLinkButtonHitsIt(page: Page): Promise<boolean> {
+  return page.evaluate((selector) => {
+    const button = document.querySelector(selector);
+    if (!button) return false;
+    const box = button.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      box.left + box.width / 2,
+      box.top + box.height / 2,
+    );
+    return !!hit && button.contains(hit);
+  }, LINK_BUTTON);
+}
+
+async function isWithinViewport(
+  page: Page,
+  selector: string,
+): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return false;
+    const box = el.getBoundingClientRect();
+    return box.top >= 0 && box.bottom <= window.innerHeight;
+  }, selector);
+}
+
+test.describe("Article link dialog", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    allowLeavingTheEditor(page);
+    await login(page);
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("link button stays clickable after scrolling into a long article", async () => {
+    const { projectId, articleId } = await openBlankArticleEditor(page);
+
+    try {
+      // Long enough that the toolbar has scrolled up into the sticky chrome.
+      await typeParagraphs(page, 40);
+
+      const target = editorBody(page).locator("p", {
+        hasText: "Paragraph number 35",
+      });
+      await target.scrollIntoViewIfNeeded();
+      await target.dblclick();
+
+      expect(await centreOfLinkButtonHitsIt(page)).toBe(true);
+
+      await page.locator(LINK_BUTTON).click();
+
+      await expect(page.locator(LINK_DIALOG)).toBeVisible();
+      expect(await isWithinViewport(page, LINK_DIALOG)).toBe(true);
+    } finally {
+      await cleanUp(page, projectId, articleId);
+    }
+  });
+
+  test("link button opens the dialog in a short article", async () => {
+    const { projectId, articleId } = await openBlankArticleEditor(page);
+
+    try {
+      await editorBody(page).click();
+      await page.keyboard.type("Just a short sentence here.");
+      await editorBody(page).locator("p").first().dblclick();
+
+      expect(await centreOfLinkButtonHitsIt(page)).toBe(true);
+      await page.locator(LINK_BUTTON).click();
+
+      await expect(page.locator(LINK_DIALOG)).toBeVisible();
+      expect(await isWithinViewport(page, LINK_DIALOG)).toBe(true);
+    } finally {
+      await cleanUp(page, projectId, articleId);
+    }
+  });
+});

--- a/src/web-ui/e2e/article-listing-image.spec.ts
+++ b/src/web-ui/e2e/article-listing-image.spec.ts
@@ -1,64 +1,28 @@
 import { test, expect, type Page } from "@playwright/test";
 import * as path from "path";
+import {
+  allowLeavingTheEditor,
+  cleanUp,
+  editorBody,
+  fetchArticle,
+  imagePicker,
+  login,
+  openBlankArticleEditor,
+  trackUploadedImageIds,
+} from "./helpers";
 
 const FIXTURES = path.join(__dirname, "fixtures");
 const IMAGE = path.join(FIXTURES, "inline-image.png");
 
-// /api/auth/login is rate limited to 5/min per IP, so this file logs in once
-// and runs serially. Projects also cap at 10 gallery images — article uploads
-// do not count towards that, but each test still puts its own uploads back.
+// One login for the file: /api/auth/login allows 5/min per IP. Projects also
+// cap at 10 gallery images — article uploads do not count towards that, but
+// each test still puts its own uploads back.
 test.describe.configure({ mode: "serial" });
-
-async function login(page: Page) {
-  const password = process.env.TEST_USER_PASSWORD;
-  if (!password) {
-    throw new Error(
-      "TEST_USER_PASSWORD not set. Make sure .env.claude exists with credentials.",
-    );
-  }
-
-  await page.goto("/login");
-  await page.fill("#email", process.env.TEST_USER_EMAIL || "test@example.com");
-  await page.fill("#password", password);
-  await page.click('button[type="submit"]');
-  await expect(page).toHaveURL(/\/my-projects/);
-}
-
-// Walks from the project list to a blank article editor, so the test doesn't
-// hard-code a project slug. The New article button creates the draft and routes
-// straight to its editor, so this returns both ids.
-async function openBlankArticleEditor(
-  page: Page,
-): Promise<{ projectId: string; articleId: string }> {
-  await page.goto("/my-projects");
-  await page.locator('a[href^="/my-projects/"]').last().click();
-  await expect(page).toHaveURL(/\/my-projects\/[0-9a-f-]+$/);
-  const projectId = page.url().split("/").pop()!;
-
-  // The button lives behind a tab, and it is the thing that creates the draft —
-  // there is no route to navigate to instead.
-  await page.getByRole("button", { name: "Articles", exact: true }).click();
-  await page.getByRole("button", { name: "New article" }).click();
-
-  // The draft is created by the click, so the editor opens on /edit/<id>
-  // before the author types anything.
-  await expect(page).toHaveURL(/\/articles\/edit\/[0-9a-f-]+$/);
-  await expect(page.locator('input[placeholder="Article title"]')).toBeVisible();
-
-  return { projectId, articleId: page.url().split("/").pop()! };
-}
-
-const editorBody = (page: Page) =>
-  page.locator('[contenteditable="true"]').first();
-
-// The toolbar's insert button drives a hidden file input rather than a dialog.
-const bodyImagePicker = (page: Page) =>
-  page.locator('.mdxeditor input[type="file"]').first();
 
 const bodyImages = (page: Page) => editorBody(page).locator("img");
 
 async function insertBodyImage(page: Page, index: number) {
-  await bodyImagePicker(page).setInputFiles(IMAGE);
+  await imagePicker(page).setInputFiles(IMAGE);
   await expect(bodyImages(page)).toHaveCount(index + 1, { timeout: 30_000 });
 }
 
@@ -95,20 +59,8 @@ async function savedListingImageId(
   projectId: string,
   articleId: string,
 ): Promise<string | null> {
-  return page.evaluate(
-    async ({ projectId, articleId }) => {
-      const article = await fetch(
-        `http://localhost:8000/api/projects/${projectId}/articles/${articleId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("access_token")}`,
-          },
-        },
-      ).then((r) => r.json());
-      return article.listing_image_id ?? null;
-    },
-    { projectId, articleId },
-  );
+  const article = await fetchArticle(page, projectId, articleId);
+  return (article.listing_image_id as string | null) ?? null;
 }
 
 // Scoped to the dialog: Next.js dev tools puts its own "Next" button on the
@@ -134,62 +86,6 @@ async function chooseListingImage(page: Page, index: number) {
 
 async function removeListingImage(page: Page) {
   await page.getByRole("button", { name: "Remove", exact: true }).click();
-}
-
-// Article uploads are excluded from `project.images`, so cleanup cannot find
-// them by listing the project. Record the ids the backend hands out instead.
-function trackUploadedImageIds(page: Page): string[] {
-  const ids: string[] = [];
-  page.on("response", async (response) => {
-    if (!response.url().endsWith("/images/upload-url") || !response.ok()) return;
-    const body = await response.json().catch(() => null);
-    if (body?.image_id) ids.push(body.image_id);
-  });
-  return ids;
-}
-
-// Deleting the article cascades its linked images, but the ids are tracked and
-// deleted too so a failure part-way through still cleans up.
-async function cleanUp(
-  page: Page,
-  projectId: string,
-  articleId: string,
-  imageIds: string[],
-) {
-  await page.evaluate(
-    async ({ projectId, articleId, imageIds }) => {
-      const apiUrl = "http://localhost:8000";
-      const headers = {
-        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
-      };
-
-      await Promise.all(
-        imageIds.map((imageId: string) =>
-          fetch(
-            `${apiUrl}/api/projects/${projectId}/articles/${articleId}/images/${imageId}`,
-            { method: "DELETE", headers },
-          ),
-        ),
-      );
-      await fetch(`${apiUrl}/api/projects/${projectId}/articles/${articleId}`, {
-        method: "DELETE",
-        headers,
-      });
-    },
-    { projectId, articleId, imageIds: imageIds.splice(0) },
-  );
-}
-
-// The editor guards against losing an unsaved body, so navigating away from it
-// raises a beforeunload prompt. Every navigation in these tests is deliberate.
-function allowLeavingTheEditor(page: Page) {
-  page.on("dialog", (dialog) => {
-    if (dialog.type() === "beforeunload") {
-      void dialog.accept();
-    } else {
-      void dialog.dismiss();
-    }
-  });
 }
 
 test.describe("Article listing image", () => {

--- a/src/web-ui/e2e/helpers.ts
+++ b/src/web-ui/e2e/helpers.ts
@@ -1,0 +1,131 @@
+import { expect, type Page } from "@playwright/test";
+
+/*
+ * Shared walk-ins for the article editor specs. Anything used by one spec only
+ * stays in that spec.
+ */
+
+// The e2e stack is `make dev` in both services, so the backend origin is fixed.
+// Passed into `page.evaluate` rather than closed over — that code runs in the
+// browser, where this module does not exist.
+export const API_URL = "http://localhost:8000";
+
+// Credentials come from .env.claude, which playwright.config.ts parses itself.
+// Login is rate limited to 5/min per IP, so a spec logs in once in `beforeAll`
+// against a shared page and runs `mode: "serial"`, not once per test.
+export async function login(page: Page) {
+  const password = process.env.TEST_USER_PASSWORD;
+  if (!password) {
+    throw new Error(
+      "TEST_USER_PASSWORD not set. Make sure .env.claude exists with credentials.",
+    );
+  }
+
+  await page.goto("/login");
+  await page.fill("#email", process.env.TEST_USER_EMAIL || "test@example.com");
+  await page.fill("#password", password);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(/\/my-projects/);
+}
+
+export const editorBody = (page: Page) =>
+  page.locator('[contenteditable="true"]').first();
+
+// The toolbar's insert button drives a hidden file input rather than a dialog.
+export const imagePicker = (page: Page) =>
+  page.locator('.mdxeditor input[type="file"]').first();
+
+// Walks from the project list to a blank article editor, so specs don't
+// hard-code a project slug. The New article button is what creates the draft —
+// there is no editor route to navigate to instead — so this returns both ids.
+// Settling on the editor means the title input is up too; it renders first.
+export async function openBlankArticleEditor(
+  page: Page,
+): Promise<{ projectId: string; articleId: string }> {
+  await page.goto("/my-projects");
+  await page.locator('a[href^="/my-projects/"]').last().click();
+  await expect(page).toHaveURL(/\/my-projects\/[0-9a-f-]+$/);
+  const projectId = page.url().split("/").pop()!;
+
+  await page.getByRole("button", { name: "Articles", exact: true }).click();
+  await page.getByRole("button", { name: "New article" }).click();
+  await expect(page).toHaveURL(/\/articles\/edit\/[0-9a-f-]+$/);
+  await expect(editorBody(page)).toBeVisible();
+
+  return { projectId, articleId: page.url().split("/").pop()! };
+}
+
+// Article uploads are excluded from `project.images`, so cleanup cannot find
+// them by listing the project. Record the ids the backend hands out instead.
+export function trackUploadedImageIds(page: Page): string[] {
+  const ids: string[] = [];
+  page.on("response", async (response) => {
+    if (!response.url().endsWith("/images/upload-url") || !response.ok())
+      return;
+    const body = await response.json().catch(() => null);
+    if (body?.image_id) ids.push(body.image_id);
+  });
+  return ids;
+}
+
+// The article's JSON, for assertions the DOM cannot answer — two uploads of one
+// fixture look identical on screen but carry different ids.
+export async function fetchArticle(
+  page: Page,
+  projectId: string,
+  articleId: string,
+): Promise<Record<string, unknown>> {
+  return page.evaluate(
+    async ({ apiUrl, projectId, articleId }) =>
+      fetch(`${apiUrl}/api/projects/${projectId}/articles/${articleId}`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+        },
+      }).then((r) => r.json()),
+    { apiUrl: API_URL, projectId, articleId },
+  );
+}
+
+// Deleting the article cascades its linked images; tracked ids are deleted too
+// so a run that failed part-way still cleans up. Every test leaves a draft
+// behind, because opening the editor creates one.
+export async function cleanUp(
+  page: Page,
+  projectId: string,
+  articleId: string,
+  imageIds: string[] = [],
+) {
+  await page.evaluate(
+    async ({ apiUrl, projectId, articleId, imageIds }) => {
+      const headers = {
+        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+      };
+
+      await Promise.all(
+        imageIds.map((imageId: string) =>
+          fetch(
+            `${apiUrl}/api/projects/${projectId}/articles/${articleId}/images/${imageId}`,
+            { method: "DELETE", headers },
+          ),
+        ),
+      );
+      await fetch(`${apiUrl}/api/projects/${projectId}/articles/${articleId}`, {
+        method: "DELETE",
+        headers,
+      });
+    },
+    { apiUrl: API_URL, projectId, articleId, imageIds: imageIds.splice(0) },
+  );
+}
+
+// The editor guards against losing an unsaved body, so navigating away from it
+// raises a beforeunload prompt. Every navigation in these specs is deliberate.
+export function allowLeavingTheEditor(page: Page) {
+  page.on("dialog", (dialog) => {
+    if (dialog.type() === "beforeunload") {
+      void dialog.accept();
+    } else {
+      void dialog.dismiss();
+    }
+  });
+}

--- a/src/web-ui/src/app/projects/[slug]/articles/ArticleAuthoringPage.tsx
+++ b/src/web-ui/src/app/projects/[slug]/articles/ArticleAuthoringPage.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { type CSSProperties, useMemo, useState } from "react";
 import { ArrowPathIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "@/contexts/auth";
 import type { Project } from "@/lib/api";
@@ -12,6 +12,7 @@ import { ChannelDropdown } from "./ChannelDropdown";
 import { ListingImageDialog } from "./ListingImageDialog";
 import { ListingSettingsPanel } from "./ListingSettingsPanel";
 import { useArticleDraft } from "./useArticleDraft";
+import { useStickyChromeOffset } from "./useStickyChromeOffset";
 
 // The import stays inline: next/dynamic's compile-time transform has to see the
 // literal `import()` to register the chunk in the loadable manifest. Hoisting
@@ -50,6 +51,9 @@ export function ArticleAuthoringPage({ project, articleId }: Props) {
   const projectRef = project.slug ?? project.id;
 
   const draft = useArticleDraft({ project, articleId });
+  // The editor's own toolbar is sticky as well, and has to come to rest below
+  // the action bar rather than behind it. See article-markdown.css.
+  const { ref: actionBarRef, offset: chromeOffset } = useStickyChromeOffset();
   const [showPublishDialog, setShowPublishDialog] = useState(false);
   const [showImageWizard, setShowImageWizard] = useState(false);
   const [tab, setTab] = useState<Tab>("content");
@@ -140,7 +144,10 @@ export function ArticleAuthoringPage({ project, articleId }: Props) {
 
   return (
     <>
-      <div className="sticky top-14 z-30 bg-white border-b border-border">
+      <div
+        ref={actionBarRef}
+        className="sticky top-14 z-30 bg-white border-b border-border"
+      >
         <div className="max-w-4xl mx-auto px-4 sm:px-6 flex items-center justify-between py-2">
           <div className="text-sm text-muted-foreground">
             <Link
@@ -209,7 +216,12 @@ export function ArticleAuthoringPage({ project, articleId }: Props) {
         </div>
       </div>
 
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 space-y-4">
+      <div
+        className="max-w-4xl mx-auto px-4 sm:px-6 py-6 space-y-4"
+        style={
+          { "--article-chrome-offset": `${chromeOffset}px` } as CSSProperties
+        }
+      >
         {/* Above the tabs: the title is article identity and it is what the
             card preview renders, so tuning a headline for the card should not
             mean changing tabs. */}

--- a/src/web-ui/src/app/projects/[slug]/articles/ArticleEditor.tsx
+++ b/src/web-ui/src/app/projects/[slug]/articles/ArticleEditor.tsx
@@ -57,7 +57,7 @@ export function ArticleEditor({
   );
 
   return (
-    <div className="rounded-lg border border-border bg-white">
+    <div className="article-editor rounded-lg border border-border bg-white">
       <ImageUploadStatusBar status={status} onDismissError={dismissError} />
       <MDXEditor
         ref={editorRef}

--- a/src/web-ui/src/app/projects/[slug]/articles/article-markdown.css
+++ b/src/web-ui/src/app/projects/[slug]/articles/article-markdown.css
@@ -49,7 +49,8 @@
  * span is inline by default, which kills `margin: auto` on the image. Force
  * the decorator to block-flow and center its inline-block child so the editor
  * view matches the rendered article view. */
-.markdown-article [data-lexical-decorator]:has([data-editor-block-type="image"]) {
+.markdown-article
+  [data-lexical-decorator]:has([data-editor-block-type="image"]) {
   display: block;
   text-align: center;
 }
@@ -69,7 +70,8 @@
 
 /* Inline code: `like this` */
 .markdown-article :not(pre) > code {
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 0.875em;
   padding: 0.15em 0.4em;
   background-color: var(--article-code-inline-bg);
@@ -90,7 +92,8 @@
 }
 
 .markdown-article pre > code {
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   background: none;
   padding: 0;
   color: inherit;
@@ -155,4 +158,21 @@
 .markdown-article pre .token.important,
 .markdown-article pre .token.variable {
   color: var(--article-code-regex);
+}
+
+/* --- Editor toolbar ------------------------------------------------------ */
+
+/*
+ * MDXEditor's toolbar is `position: sticky; top: 0`, so scrolling into a long
+ * article parks it behind the fixed site nav and the sticky action bar: hidden,
+ * and clicks at it land on the header. Re-park it below that chrome, at the
+ * offset `useStickyChromeOffset` measures off the action bar.
+ *
+ * Scoping to `.article-editor` outranks the library's own `.toolbarRoot` rule
+ * without depending on stylesheet order. `mdxeditor-toolbar` is the stable
+ * class the library sets alongside its hashed one — an upgrade that drops it
+ * puts the bug back, and only the Playwright spec would notice.
+ */
+.article-editor .mdxeditor-toolbar {
+  top: var(--article-chrome-offset, 113px);
 }

--- a/src/web-ui/src/app/projects/[slug]/articles/sticky-chrome-offset.test.tsx
+++ b/src/web-ui/src/app/projects/[slug]/articles/sticky-chrome-offset.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useStickyChromeOffset } from "./useStickyChromeOffset";
+
+// ------------------------------------------------------------------ harness
+
+// jsdom has no layout, so the measured element's height is stubbed on the
+// prototype and its sticky offset comes from an inline style, which
+// getComputedStyle does report.
+function stubElementHeight(height: number) {
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get: () => height,
+  });
+}
+
+function stubResizeObserver() {
+  const callbacks: (() => void)[] = [];
+  const disconnect = vi.fn();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: () => void) {
+        callbacks.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect = disconnect;
+    },
+  );
+  return { resize: () => act(() => callbacks.forEach((cb) => cb())), disconnect };
+}
+
+// `rendered` stands in for the authoring page's loading state, which returns a
+// skeleton before the action bar exists.
+function Harness({
+  stickyTop,
+  rendered,
+  onOffset,
+}: {
+  stickyTop: string;
+  rendered: boolean;
+  onOffset: (value: number) => void;
+}) {
+  const { ref, offset } = useStickyChromeOffset();
+  onOffset(offset);
+  if (!rendered) return <span />;
+  return <div ref={ref} style={{ position: "sticky", top: stickyTop }} />;
+}
+
+async function mountHarness({
+  stickyTop = "56px",
+  rendered = true,
+}: { stickyTop?: string; rendered?: boolean } = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root;
+  const offsets: number[] = [];
+  const render = (isRendered: boolean) =>
+    root.render(
+      <Harness
+        stickyTop={stickyTop}
+        rendered={isRendered}
+        onOffset={(value) => offsets.push(value)}
+      />,
+    );
+  await act(async () => {
+    root = createRoot(container);
+    render(rendered);
+  });
+  return {
+    latestOffset: () => offsets[offsets.length - 1],
+    show: async () => {
+      await act(async () => render(true));
+    },
+    unmount: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+// -------------------------------------------------------------------- tests
+
+describe("useStickyChromeOffset", () => {
+  it("measures the element's own sticky offset plus its height", async () => {
+    stubElementHeight(57);
+    stubResizeObserver();
+
+    const harness = await mountHarness({ stickyTop: "56px" });
+
+    expect(harness.latestOffset()).toBe(113);
+    await harness.unmount();
+  });
+
+  it("re-measures when the element changes height", async () => {
+    stubElementHeight(57);
+    const observer = stubResizeObserver();
+
+    const harness = await mountHarness({ stickyTop: "56px" });
+    stubElementHeight(77);
+    observer.resize();
+
+    expect(harness.latestOffset()).toBe(133);
+    await harness.unmount();
+  });
+
+  it("treats an unpositioned element as having no offset of its own", async () => {
+    stubElementHeight(57);
+    stubResizeObserver();
+
+    const harness = await mountHarness({ stickyTop: "auto" });
+
+    expect(harness.latestOffset()).toBe(57);
+    await harness.unmount();
+  });
+
+  it("measures an element that only appears after the first render", async () => {
+    stubElementHeight(77);
+    stubResizeObserver();
+
+    const harness = await mountHarness({ rendered: false });
+    expect(harness.latestOffset()).toBe(113); // the fallback
+
+    await harness.show();
+
+    expect(harness.latestOffset()).toBe(133);
+    await harness.unmount();
+  });
+
+  it("stops observing once unmounted", async () => {
+    stubElementHeight(57);
+    const observer = stubResizeObserver();
+
+    const harness = await mountHarness();
+    await harness.unmount();
+
+    expect(observer.disconnect).toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/app/projects/[slug]/articles/useStickyChromeOffset.ts
+++ b/src/web-ui/src/app/projects/[slug]/articles/useStickyChromeOffset.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Where the sticky chrome ends before anything has been measured: the site nav
+// (h-14 plus its border) and a one-line action bar. First paint only, and
+// environments without layout — the real number comes from the element.
+const FALLBACK_OFFSET_PX = 113;
+
+/**
+ * Measures where a sticky element comes to rest, so something below it can
+ * stick clear of it rather than underneath.
+ *
+ * Measured rather than hard-coded because the action bar's height moves: a long
+ * breadcrumb or a save message wraps once the row is narrow enough.
+ */
+export function useStickyChromeOffset() {
+  // A callback ref, not a ref object: the authoring page renders a skeleton
+  // first, so the element appears a render or two after the hook mounts.
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+  const [offset, setOffset] = useState(FALLBACK_OFFSET_PX);
+
+  useEffect(() => {
+    if (!element) return;
+
+    const measure = () => {
+      // Its own sticky offset, not `getBoundingClientRect`: the rect says where
+      // the bar is now, which is lower until the author has scrolled past it.
+      const ownOffset = parseFloat(window.getComputedStyle(element).top);
+      setOffset(
+        (Number.isNaN(ownOffset) ? 0 : ownOffset) + element.offsetHeight,
+      );
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element]);
+
+  return { ref: setElement, offset };
+}


### PR DESCRIPTION
Closes #85.

## The bug

MDXEditor's toolbar is `position: sticky; top: 0`. The authoring page puts a
fixed site nav and a sticky action bar above it, so once you scroll into a long
article the toolbar parks *behind* that chrome — invisible, and a click aimed at
the link button lands on the header instead. Which is why adding a link to a
long article did nothing.

## The fix

Re-park the toolbar below the chrome. The offset isn't hard-coded: the action
bar's height moves when a long breadcrumb or a save message wraps, so
`useStickyChromeOffset` measures the bar's resting position (its own sticky
`top` plus its height, re-measured through a `ResizeObserver`) and the authoring
page publishes it as `--article-chrome-offset`. The CSS rule is scoped to
`.article-editor` so it outranks the library's own `.toolbarRoot` without
depending on stylesheet order.

## Tests

- `sticky-chrome-offset.test.tsx` covers the hook: the measurement, re-measuring
  on resize, an unpositioned element, an element that only mounts after the
  first render, and teardown.
- `e2e/article-link-dialog.spec.ts` covers the behaviour that actually broke. It
  asserts with `elementFromPoint` rather than `toBeVisible`, because an element
  covered by the site header is still "visible" to Playwright.

Playwright isn't in CI, so the second suite has to be run by hand. All 9 article
e2e tests pass locally against `make dev` in both services.

## Also here

The three article specs each carried their own copy of `login()`,
`openBlankArticleEditor()` and friends. They now share `e2e/helpers.ts`, and the
new spec follows the existing one-login-per-file serial pattern — `/api/auth/login`
is rate limited to 5/min per IP, and logging in per test doesn't survive the
suite running in parallel.